### PR TITLE
Add make game.dylib for Darwin

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -155,6 +155,16 @@ build/%.o: %.c
 	@echo "===> CC $<"
 	${Q}mkdir -p $(@D)
 	${Q}$(CC) -c $(CFLAGS) -o $@ $<
+ifeq ($(OSTYPE), Darwin)
+rogue:
+	@echo "===> Building game.dylib"
+	${Q}mkdir -p release
+	$(MAKE) release/game.dylib
+
+build/%.o: %.c
+	@echo "===> CC $<"
+	${Q}mkdir -p $(@D)
+	${Q}$(CC) -c $(CFLAGS) -o $@ $<
 else
 rogue:
 	@echo "===> Building game.so"


### PR DESCRIPTION
Previously there was no ability to compile game.dylib for Darwin and would result in Issue #14 
This addition will allow the compiling of game.dylib

I am uncertain if `release/game.so : CFLAGS += -fPIC` is also required for Darwin. This may need to be confirmed.