### PR TITLE
Killtarget teamchain cleanup crash fix

### DIFF
--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -269,7 +269,6 @@ G_UseTargets(edict_t *ent, edict_t *activator)
 {
 	edict_t *t;
 	edict_t *master;
-	qboolean done = false;
 
 	if (!ent || !activator)
 	{
@@ -322,20 +321,17 @@ G_UseTargets(edict_t *ent, edict_t *activator)
 			/* if this entity is part of a train, cleanly remove it */
 			if (t->flags & FL_TEAMSLAVE)
 			{
-				if (t->teammaster)
+				master = t->teammaster;
+
+				while (master)
 				{
-					master = t->teammaster;
-
-					while (!done)
+					if (master->teamchain == t)
 					{
-						if (master->teamchain == t)
-						{
-							master->teamchain = t->teamchain;
-							done = true;
-						}
-
-						master = master->teamchain;
+						master->teamchain = t->teamchain;
+						break;
 					}
+
+					master = master->teamchain;
 				}
 			}
 


### PR DESCRIPTION
This pull request implements the fix for bug https://github.com/yquake2/rogue/issues/20. This bug crashes the game every time you press the self-destruct button in map biggun, rendering the baseq2 campaign unbeatable in rogue, and possibly could affect some custom maps as well.

(Do not confuse this bug with the infamous biggun crash. That was caused by heap corruption, that is a separate bug and was already addressed a long time ago.)

Background and details: Rogue added code to G_UseTargets that cleans up teamchains for teamslave entities when they are being killed by killtarget. It made the dangerous assumption that teamchains are always in a consistent state where the teamslave must surely always exist in its teamchain. This was indeed not the case in biggun, where some entity is being freed without cleaning up the teamchain, causing it to split in two parts unaware of each other. The crash occurs because the while-loop condition for traveling down the teamchain does not check the master pointer for NULL, so if NULL is encountered before the entity in the teamchain, the game crashes.

The fix was simply to get rid of the done variable and use master as the loop condition.

For future reference, it may be worthwhile to investigate why the teamchain is being corrupted. Do we perhaps want to add teamchain cleanups into G_FreeEdict to ensure they are always cleaned up before an entity is freed?