### PR TITLE
coop_baseq2 added to rogue for playing co-op in baseq2 maps

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -22,6 +22,7 @@ edict_t *g_edicts;
 
 cvar_t *deathmatch;
 cvar_t *coop;
+cvar_t *coop_baseq2;	/* treat spawnflags according to baseq2 rules */
 cvar_t *dmflags;
 cvar_t *skill;
 cvar_t *fraglimit;

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -846,7 +846,7 @@ SpawnEntities(const char *mapname, char *entities, const char *spawnpoint)
 					continue;
 				}
 			}
-			else if (coop->value)
+			else if (coop->value && !coop_baseq2->value)
 			{
 				if (ent->spawnflags & SPAWNFLAG_NOT_COOP)
 				{

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -576,6 +576,7 @@ extern edict_t *g_edicts;
 extern cvar_t *maxentities;
 extern cvar_t *deathmatch;
 extern cvar_t *coop;
+extern cvar_t *coop_baseq2;	/* treat spawnflags according to baseq2 rules */
 extern cvar_t *dmflags;
 extern cvar_t *skill;
 extern cvar_t *fraglimit;

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -213,6 +213,7 @@ InitGame(void)
 	maxspectators = gi.cvar ("maxspectators", "4", CVAR_SERVERINFO);
 	deathmatch = gi.cvar ("deathmatch", "0", CVAR_LATCH);
 	coop = gi.cvar ("coop", "0", CVAR_LATCH);
+	coop_baseq2 = gi.cvar ("coop_baseq2", "0", CVAR_LATCH);
 	skill = gi.cvar ("skill", "1", CVAR_LATCH);
 	maxentities = gi.cvar ("maxentities", "1024", CVAR_LATCH);
 	gamerules = gi.cvar ("gamerules", "0", CVAR_LATCH);			//PGM


### PR DESCRIPTION
This pull request adds the suggested coop_baseq2 (https://github.com/yquake2/rogue/issues/29).

It is a latched cvar. Default value is 0. Set to non-0 to enable. When enabled, baseq2 maps will work correctly in rogue co-op.