### PR TITLE
Restored blocked code for gladiator

### DIFF
--- a/src/monster/gladiator/gladiator.c
+++ b/src/monster/gladiator/gladiator.c
@@ -466,6 +466,27 @@ gladiator_die(edict_t *self, edict_t *inflictor /* unused */, edict_t *attacker 
 	self->monsterinfo.currentmove = &gladiator_move_death;
 }
 
+qboolean
+gladiator_blocked(edict_t *self, float dist)
+{
+	if (!self)
+	{
+		return false;
+	}
+
+	if (blocked_checkshot(self, 0.25 + (0.05 * skill->value) ))
+	{
+		return true;
+	}
+
+	if (blocked_checkplat(self, dist))
+	{
+		return true;
+	}
+
+	return false;
+}
+
 /*
  * QUAKED monster_gladiator (1 .5 0) (-32 -32 -24) (32 32 64) Ambush Trigger_Spawn Sight
  */
@@ -516,6 +537,7 @@ SP_monster_gladiator(edict_t *self)
 	self->monsterinfo.sight = gladiator_sight;
 	self->monsterinfo.idle = gladiator_idle;
 	self->monsterinfo.search = gladiator_search;
+	self->monsterinfo.blocked = gladiator_blocked;
 
 	gi.linkentity(self);
 	self->monsterinfo.currentmove = &gladiator_move_stand;

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -587,6 +587,7 @@ extern void gunner_search ( edict_t * self ) ;
 extern void gunner_sight ( edict_t * self , edict_t * other ) ;
 extern void gunner_idlesound ( edict_t * self ) ;
 extern void SP_monster_gladiator ( edict_t * self ) ;
+qboolean gladiator_blocked ( edict_t *self , float dist ) ;
 extern void gladiator_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
 extern void gladiator_dead ( edict_t * self ) ;
 extern void gladiator_pain ( edict_t * self , edict_t * other , float kick , int damage ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -587,6 +587,7 @@
 {"gunner_sight", (byte *)gunner_sight},
 {"gunner_idlesound", (byte *)gunner_idlesound},
 {"SP_monster_gladiator", (byte *)SP_monster_gladiator},
+{"gladiator_blocked", (byte *)gladiator_blocked},
 {"gladiator_die", (byte *)gladiator_die},
 {"gladiator_dead", (byte *)gladiator_dead},
 {"gladiator_pain", (byte *)gladiator_pain},


### PR DESCRIPTION
This pull request restores rogue-specific code for the gladiator: https://github.com/yquake2/rogue/issues/40

Tested in-game and saves/loads work correctly.

As far as I know this is the only thing missing, but it may be a good idea to do a careful diff analysis.