### PR TITLE
Fixed monsters not sidestepping

### DIFF
--- a/src/g_ai.c
+++ b/src/g_ai.c
@@ -1122,7 +1122,7 @@ ai_run_slide(edict_t *self, float distance)
 	/* clamp maximum sideways move for non flyers to make them look less jerky */
 	if (!(self->flags & FL_FLY))
 	{
-		distance = min(distance, 0.8);
+		distance = min(distance, 8.0);
 	}
 
 	if (M_walkmove(self, self->ideal_yaw + ofs, distance))


### PR DESCRIPTION
This pull request fixes bug https://github.com/yquake2/rogue/issues/44 by changing numeric constant 0.8 to its correct value of 8.0 in ai_run_slide().