### PR TITLE
Restored floater rogue features

### DIFF
--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -629,6 +629,7 @@ extern void flyer_pop_blades ( edict_t * self ) ;
 extern void flyer_idle ( edict_t * self ) ;
 extern void flyer_sight ( edict_t * self , edict_t * other ) ;
 extern void SP_monster_floater ( edict_t * self ) ;
+extern qboolean floater_blocked ( edict_t * self , float dist ) ;
 extern void floater_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
 extern void floater_dead ( edict_t * self ) ;
 extern void floater_pain ( edict_t * self , edict_t * other , float kick , int damage ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -629,6 +629,7 @@
 {"flyer_idle", (byte *)flyer_idle},
 {"flyer_sight", (byte *)flyer_sight},
 {"SP_monster_floater", (byte *)SP_monster_floater},
+{"floater_blocked", (byte *)floater_blocked},
 {"floater_die", (byte *)floater_die},
 {"floater_dead", (byte *)floater_dead},
 {"floater_pain", (byte *)floater_pain},

--- a/src/savegame/tables/gamemmove_decs.h
+++ b/src/savegame/tables/gamemmove_decs.h
@@ -252,6 +252,7 @@ extern mmove_t floater_move_pain1 ;
 extern mmove_t floater_move_death ;
 extern mmove_t floater_move_attack3 ;
 extern mmove_t floater_move_attack2 ;
+extern mmove_t floater_move_attack1a ;
 extern mmove_t floater_move_attack1 ;
 extern mmove_t floater_move_activate ;
 extern mmove_t floater_move_stand2 ;

--- a/src/savegame/tables/gamemmove_list.h
+++ b/src/savegame/tables/gamemmove_list.h
@@ -252,6 +252,7 @@
 {"floater_move_death", &floater_move_death},
 {"floater_move_attack3", &floater_move_attack3},
 {"floater_move_attack2", &floater_move_attack2},
+{"floater_move_attack1a", &floater_move_attack1a},
 {"floater_move_attack1", &floater_move_attack1},
 {"floater_move_activate", &floater_move_activate},
 {"floater_move_stand2", &floater_move_stand2},


### PR DESCRIPTION
This pull request fixes bug https://github.com/yquake2/rogue/issues/39.

The features restored are:
1. Floater circle strafe attack (floater_move_attack1a)
2. Blocked code