### PR TITLE
Restored mutant rogue features

### DIFF
--- a/src/monster/mutant/mutant.c
+++ b/src/monster/mutant/mutant.c
@@ -804,6 +804,117 @@ mutant_die(edict_t *self, edict_t *inflictor /* unused */, edict_t *attacker /* 
 	}
 }
 
+void
+mutant_jump_down(edict_t *self)
+{
+	vec3_t forward, up;
+
+	if (!self)
+	{
+		return;
+	}
+
+	AngleVectors(self->s.angles, forward, NULL, up);
+	VectorMA(self->velocity, 100, forward, self->velocity);
+	VectorMA(self->velocity, 300, up, self->velocity);
+}
+
+void
+mutant_jump_up(edict_t *self)
+{
+	vec3_t forward, up;
+
+	if (!self)
+	{
+		return;
+	}
+
+	AngleVectors(self->s.angles, forward, NULL, up);
+	VectorMA(self->velocity, 200, forward, self->velocity);
+	VectorMA(self->velocity, 450, up, self->velocity);
+}
+
+void
+mutant_jump_wait_land(edict_t *self)
+{
+	if (self->groundentity == NULL)
+	{
+		self->monsterinfo.nextframe = self->s.frame;
+	}
+	else 
+	{
+		self->monsterinfo.nextframe = self->s.frame + 1;
+	}
+}
+
+mframe_t mutant_frames_jump_up[] = {
+	{ai_move, -8, NULL},
+	{ai_move, -8, mutant_jump_up},
+	{ai_move, 0, mutant_jump_wait_land},
+	{ai_move, 0, NULL},
+	{ai_move, 0, NULL}
+};
+
+mmove_t mutant_move_jump_up = {
+	FRAME_jump01,
+	FRAME_jump05,
+	mutant_frames_jump_up,
+	mutant_run
+};
+
+mframe_t mutant_frames_jump_down[] = {
+	{ai_move, 0, NULL},
+	{ai_move, 0, mutant_jump_down},
+	{ai_move, 0, mutant_jump_wait_land},
+	{ai_move, 0, NULL},
+	{ai_move, 0, NULL}
+};
+
+mmove_t mutant_move_jump_down = {
+	FRAME_jump01,
+	FRAME_jump05,
+	mutant_frames_jump_down,
+	mutant_run
+};
+
+void
+mutant_jump_updown(edict_t *self)
+{
+	if (!self || !self->enemy)
+	{
+		return;
+	}
+
+	if (self->enemy->s.origin[2] > self->s.origin[2])
+	{
+		self->monsterinfo.currentmove = &mutant_move_jump_up;
+	}
+	else
+	{
+		self->monsterinfo.currentmove = &mutant_move_jump_down;
+	}
+}
+
+qboolean
+mutant_blocked(edict_t *self, float dist)
+{
+	if (!self)
+	{
+		return false;
+	}
+
+	if (blocked_checkjump(self, dist, 256, 68))
+	{
+		mutant_jump_updown(self);
+		return true;
+	}
+
+	if (blocked_checkplat(self, dist))
+		return true;
+
+	return false;
+}
+
 /*
  * QUAKED monster_mutant (1 .5 0) (-32 -32 -24) (32 32 32) Ambush Trigger_Spawn Sight
  */
@@ -858,6 +969,7 @@ SP_monster_mutant(edict_t *self)
 	self->monsterinfo.search = mutant_search;
 	self->monsterinfo.idle = mutant_idle;
 	self->monsterinfo.checkattack = mutant_checkattack;
+	self->monsterinfo.blocked = mutant_blocked;
 
 	gi.linkentity(self);
 

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -443,6 +443,7 @@ extern void parasite_sight ( edict_t * self , edict_t * other ) ;
 extern void parasite_reel_in ( edict_t * self ) ;
 extern void parasite_launch ( edict_t * self ) ;
 extern void SP_monster_mutant ( edict_t * self ) ;
+extern qboolean mutant_blocked ( edict_t * self , float dist ) ;
 extern void mutant_die ( edict_t * self , edict_t * inflictor , edict_t * attacker , int damage , vec3_t point ) ;
 extern void mutant_dead ( edict_t * self ) ;
 extern void mutant_pain ( edict_t * self , edict_t * other , float kick , int damage ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -443,6 +443,7 @@
 {"parasite_reel_in", (byte *)parasite_reel_in},
 {"parasite_launch", (byte *)parasite_launch},
 {"SP_monster_mutant", (byte *)SP_monster_mutant},
+{"mutant_blocked", (byte *)mutant_blocked},
 {"mutant_die", (byte *)mutant_die},
 {"mutant_dead", (byte *)mutant_dead},
 {"mutant_pain", (byte *)mutant_pain},

--- a/src/savegame/tables/gamemmove_decs.h
+++ b/src/savegame/tables/gamemmove_decs.h
@@ -133,6 +133,8 @@ extern mmove_t parasite_move_stand ;
 extern mmove_t parasite_move_end_fidget ;
 extern mmove_t parasite_move_fidget ;
 extern mmove_t parasite_move_start_fidget ;
+extern mmove_t mutant_move_jump_down ;
+extern mmove_t mutant_move_jump_up ;
 extern mmove_t mutant_move_death2 ;
 extern mmove_t mutant_move_death1 ;
 extern mmove_t mutant_move_pain3 ;

--- a/src/savegame/tables/gamemmove_list.h
+++ b/src/savegame/tables/gamemmove_list.h
@@ -133,6 +133,8 @@
 {"parasite_move_end_fidget", &parasite_move_end_fidget},
 {"parasite_move_fidget", &parasite_move_fidget},
 {"parasite_move_start_fidget", &parasite_move_start_fidget},
+{"mutant_move_jump_down", &mutant_move_jump_down},
+{"mutant_move_jump_up", &mutant_move_jump_up},
 {"mutant_move_death2", &mutant_move_death2},
 {"mutant_move_death1", &mutant_move_death1},
 {"mutant_move_pain3", &mutant_move_pain3},


### PR DESCRIPTION
This pull request fixes bug https://github.com/yquake2/rogue/issues/48.

The restored features are:
1. Blocked code
2. Jump moves (mutant_move_jump_up and _down, performed by the blocked system)