### PR TITLE
Quad sound for quadded hand grenades and removed unused prox hand grenade stuff

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -738,6 +738,15 @@ weapon_grenade_fire(edict_t *ent, qboolean held)
 	if (is_quad)
 	{
 		damage *= damage_multiplier;
+
+		if (damage_multiplier >= 4)
+		{
+			gi.sound(ent, CHAN_ITEM, gi.soundindex("items/damage3.wav"), 1, ATTN_NORM, 0);
+		}
+		else if (damage_multiplier == 2)
+		{
+			gi.sound(ent, CHAN_ITEM, gi.soundindex("misc/ddamage3.wav"), 1, ATTN_NORM, 0);
+		}
 	}
 
 	AngleVectors(ent->client->v_angle, forward, right, up);
@@ -768,11 +777,8 @@ weapon_grenade_fire(edict_t *ent, qboolean held)
 			fire_grenade2(ent, start, forward, damage, speed,
 				timer, radius, held);
 			break;
-		case AMMO_TESLA:
-			fire_tesla(ent, start, forward, damage_multiplier, speed);
-			break;
 		default:
-			fire_prox(ent, start, forward, damage_multiplier, speed);
+			fire_tesla(ent, start, forward, damage_multiplier, speed);
 			break;
 	}
 
@@ -966,19 +972,6 @@ Weapon_Grenade(edict_t *ent)
 
 	Throw_Generic(ent, 15, 48, 5, 11, 12, pause_frames,
 			GRENADE_TIMER, weapon_grenade_fire);
-}
-
-void
-Weapon_Prox(edict_t *ent)
-{
-	static int pause_frames[] = {22, 29, 0};
-
-	if (!ent)
-	{
-		return;
-	}
-
-	Throw_Generic(ent, 7, 27, 99, 2, 4, pause_frames, 0, weapon_grenade_fire);
 }
 
 void

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -111,7 +111,6 @@ extern void Weapon_ProxLauncher ( edict_t * ent ) ;
 extern void Weapon_GrenadeLauncher ( edict_t * ent ) ;
 extern void weapon_grenadelauncher_fire ( edict_t * ent ) ;
 extern void Weapon_Tesla ( edict_t * ent ) ;
-extern void Weapon_Prox ( edict_t * ent ) ;
 extern void Weapon_Grenade ( edict_t * ent ) ;
 extern void Throw_Generic ( edict_t * ent , int FRAME_FIRE_LAST , int FRAME_IDLE_LAST , int FRAME_THROW_SOUND , int FRAME_THROW_HOLD , int FRAME_THROW_FIRE , int * pause_frames , int EXPLODE , void ( * fire ) ( edict_t * ent , qboolean held ) ) ;
 extern void weapon_grenade_fire ( edict_t * ent , qboolean held ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -111,7 +111,6 @@
 {"Weapon_GrenadeLauncher", (byte *)Weapon_GrenadeLauncher},
 {"weapon_grenadelauncher_fire", (byte *)weapon_grenadelauncher_fire},
 {"Weapon_Tesla", (byte *)Weapon_Tesla},
-{"Weapon_Prox", (byte *)Weapon_Prox},
 {"Weapon_Grenade", (byte *)Weapon_Grenade},
 {"Throw_Generic", (byte *)Throw_Generic},
 {"weapon_grenade_fire", (byte *)weapon_grenade_fire},


### PR DESCRIPTION
This pull request addresses the inconsistency reported in https://github.com/yquake2/yquake2/issues/470. Specific to rogue, hand grenades thrown with double damage will play the double damage sound instead of the quad one.

While working on this I discovered some unused code for a hand-held prox weapon and decided to remove that to simplify the situation.