### PR TITLE
Fix mguard freeze bug and improvements to frame handling

### DIFF
--- a/src/g_monster.c
+++ b/src/g_monster.c
@@ -608,11 +608,19 @@ M_MoveFrame(edict_t *self)
 		(self->monsterinfo.nextframe >= move->firstframe) &&
 		(self->monsterinfo.nextframe <= move->lastframe))
 	{
-		self->s.frame = self->monsterinfo.nextframe;
+		if (self->s.frame != self->monsterinfo.nextframe)
+		{
+			self->s.frame = self->monsterinfo.nextframe;
+			self->monsterinfo.aiflags &= ~AI_HOLD_FRAME;
+		}
+
 		self->monsterinfo.nextframe = 0;
 	}
 	else
 	{
+		/* prevent nextframe from leaking into a future move */
+		self->monsterinfo.nextframe = 0;
+
 		if (self->s.frame == move->lastframe)
 		{
 			if (move->endfunc)

--- a/src/monster/soldier/soldier.c
+++ b/src/monster/soldier/soldier.c
@@ -1668,7 +1668,6 @@ soldier_duck(edict_t *self, float eta)
 
 	if (skill->value == 0)
 	{
-		self->monsterinfo.nextframe = FRAME_duck01;
 		self->monsterinfo.currentmove = &soldier_move_duck;
 		self->monsterinfo.duck_wait_time = level.time + eta + 1;
 		return;
@@ -1678,18 +1677,14 @@ soldier_duck(edict_t *self, float eta)
 
 	if (r > (skill->value * 0.3))
 	{
-		self->monsterinfo.nextframe = FRAME_duck01;
 		self->monsterinfo.currentmove = &soldier_move_duck;
 		self->monsterinfo.duck_wait_time = level.time + eta + (0.1 * (3 - skill->value));
 	}
 	else
 	{
-		self->monsterinfo.nextframe = FRAME_attak301;
 		self->monsterinfo.currentmove = &soldier_move_attack3;
 		self->monsterinfo.duck_wait_time = level.time + eta + 1;
 	}
-
-	return;
 }
 
 mframe_t soldier_frames_blind[] = {


### PR DESCRIPTION
Fixes bug https://github.com/yquake2/rogue/issues/60 and applies the improvements suggested:

* Always reset nextframe to avoid the value lingering and causing future moves skipping frames
* Clear AI_HOLD_FRAME if current frame is successfully set to nextframe