### PR TITLE
Implement accurate-aiming CVAR in rogue game code.

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -70,6 +70,8 @@ cvar_t *randomrespawn;
 
 cvar_t *g_disruptor;
 
+cvar_t *aimfix;
+
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);
 qboolean ClientConnect(edict_t *ent, char *userinfo);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -628,6 +628,8 @@ extern cvar_t *randomrespawn;
 
 extern cvar_t *g_disruptor;
 
+extern cvar_t *aimfix;
+
 /* this is for the count of monsters */
 #define ENT_SLOTS_LEFT \
 	(ent->monsterinfo.monster_slots - \

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -245,6 +245,9 @@ InitGame(void)
 	/* disruptor availability */
 	g_disruptor = gi.cvar ("g_disruptor", "0", 0);
 
+	/* others */
+	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
+
 	/* items */
 	InitItems ();
 


### PR DESCRIPTION
Rogue-specific implementation of the changes in baseq2 PR [#561](https://github.com/yquake2/yquake2/pull/561).

I handled function P_ProjectSource2() slightly differently since the point vector that's calculated for one call to requires pre-processing to add the player's view height.