### PR TITLE
Fix CMakeLists.txt following changes to makefile.

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -19,13 +19,13 @@ set(CMAKE_C_FLAGS "${CMAKE_C_FLAGS} -Wall -fno-strict-aliasing -fwrapv")
 string(REPLACE "-O3" "-O2" CMAKE_C_FLAGS_RELEASE "${CMAKE_C_FLAGS_RELEASE}")
 
 # Operating system
-add_definitions(-DOSTYPE="${CMAKE_SYSTEM_NAME}")
+add_definitions(-DYQ2OSTYPE="${CMAKE_SYSTEM_NAME}")
 
 # Architecture string
-string(REGEX REPLACE "amd64" "x86_64" ARCH "${CMAKE_SYSTEM_PROCESSOR}")
-string(REGEX REPLACE "i.86" "i386" ARCH "${ARCH}")
-string(REGEX REPLACE "^arm.*" "arm" ARCH "${ARCH}")
-add_definitions(-DARCH="${ARCH}")
+string(REGEX REPLACE "amd64" "x86_64" YQ2_ARCH "${CMAKE_SYSTEM_PROCESSOR}")
+string(REGEX REPLACE "i.86" "i386" YQ2_ARCH "${YQ2_ARCH}")
+string(REGEX REPLACE "^arm.*" "arm" YQ2_ARCH "${YQ2_ARCH}")
+add_definitions(-DYQ2ARCH="${YQ2_ARCH}")
 
 # Linker Flags
 if(${CMAKE_SYSTEM_NAME} MATCHES "Windows")


### PR DESCRIPTION
The source won't compile with cmake at the moment due to the lack of necessary defines for savegame.c.

I'll ask it here and not on the other PR for xatrix, but any reason why you'd maintain an actual makefile as well as cmake? Why not just move to CMake full time? It'd help with the overall intention to support MSVC in the future also.