### PR TITLE
Update g_items.c

### DIFF
--- a/src/g_items.c
+++ b/src/g_items.c
@@ -405,9 +405,9 @@ Pickup_Pack(edict_t *ent, edict_t *other)
 		other->client->pers.max_slugs = 100;
 	}
 
-	if (other->client->pers.max_flechettes < 200)
+	if (other->client->pers.max_flechettes < 300)
 	{
-		other->client->pers.max_flechettes = 200;
+		other->client->pers.max_flechettes = 300;
 	}
 
 	if (g_disruptor->value)


### PR DESCRIPTION
ammopak usually increase the maximum ammo, even beyond the bandolier. i suppose there is a bug with fletchette ammo.

fletchette starts with 200 max ammo, becomes 250 max ammo with bandolier and returns to 200 max ammo with ammopack. on the contrary both cells and bullets start at 200, becomes 250 with bandolier and 300 with ammopack.