### PR TITLE
Fixed wrong Tank muzzle flash

### DIFF
--- a/src/g_newai.c
+++ b/src/g_newai.c
@@ -1746,3 +1746,48 @@ monster_jump_finished(edict_t *self)
 
 	return false;
 }
+
+qboolean
+blind_rocket_ok (edict_t *self, vec3_t start, vec3_t right, vec3_t target, float ofs,
+	vec3_t dir)
+{
+	trace_t	tr;
+	vec3_t	vec;
+
+	if (!self)
+	{
+		return false;
+	}
+
+	tr = gi.trace(start, vec3_origin, vec3_origin, target, self, MASK_SHOT);
+
+	/* since all traces have the same start point this only needs one check */
+	if (tr.startsolid)
+	{
+		return false;
+	}
+
+	if (!tr.allsolid && (tr.fraction >= 0.5f))
+	{
+		return true;
+	}
+
+	VectorMA(target, -ofs, right, vec);
+	VectorSubtract(vec, start, dir);
+	VectorNormalize(dir);
+
+	tr = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
+
+	if (!tr.allsolid && (tr.fraction >= 0.5f))
+	{
+		return true;
+	}
+
+	VectorMA(target, ofs, right, vec);
+	VectorSubtract(vec, start, dir);
+	VectorNormalize(dir);
+
+	tr = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
+
+	return !tr.allsolid && (tr.fraction >= 0.5f);
+}

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -965,6 +965,8 @@ edict_t *PickCoopTarget(edict_t *self);
 int CountPlayers(void);
 void monster_jump_start(edict_t *self);
 qboolean monster_jump_finished(edict_t *self);
+qboolean blind_rocket_ok (edict_t *self, vec3_t start, vec3_t right,
+	vec3_t target, float ofs, vec3_t dir);
 
 /* g_sphere.c */
 void Defender_Launch(edict_t *self);

--- a/src/monster/chick/chick.c
+++ b/src/monster/chick/chick.c
@@ -625,58 +625,26 @@ ChickRocket(edict_t *self)
 
 	VectorNormalize(dir);
 
-	trace = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
-
 	if (blindfire)
 	{
 		/* blindfire has different fail criteria for the trace */
-		if (!(trace.startsolid || trace.allsolid || (trace.fraction < 0.5)))
+		if (!blind_rocket_ok(self, start, right, target, 10.0f, dir))
 		{
-			monster_fire_rocket(self, start, dir, 50,
-					rocketSpeed, MZ2_CHICK_ROCKET_1);
-		}
-		else
-		{
-			VectorCopy(target, vec);
-			VectorMA(vec, -10, right, vec);
-			VectorSubtract(vec, start, dir);
-			VectorNormalize(dir);
-			trace = gi.trace(start, vec3_origin, vec3_origin, vec,
-					self, MASK_SHOT);
-
-			if (!(trace.startsolid || trace.allsolid || (trace.fraction < 0.5)))
-			{
-				monster_fire_rocket(self, start, dir, 50, rocketSpeed, MZ2_CHICK_ROCKET_1);
-			}
-			else
-			{
-				/* ok, that failed.  try to the right */
-				VectorCopy(target, vec);
-				VectorMA(vec, 10, right, vec);
-				VectorSubtract(vec, start, dir);
-				VectorNormalize(dir);
-				trace = gi.trace(start, vec3_origin, vec3_origin, vec,
-						self, MASK_SHOT);
-
-				if (!(trace.startsolid || trace.allsolid || (trace.fraction < 0.5)))
-				{
-					monster_fire_rocket(self, start, dir, 50, rocketSpeed, MZ2_CHICK_ROCKET_1);
-				}
-			}
+			return;
 		}
 	}
 	else
 	{
 		trace = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
 
-		if ((trace.ent == self->enemy) || (trace.ent == world))
+		if (((trace.ent != self->enemy) && (trace.ent != world)) ||
+			((trace.fraction <= 0.5f) && !trace.ent->client))
 		{
-			if ((trace.fraction > 0.5) || (trace.ent && trace.ent->client))
-			{
-				monster_fire_rocket(self, start, dir, 50, rocketSpeed, MZ2_CHICK_ROCKET_1);
-			}
+			return;
 		}
 	}
+
+	monster_fire_rocket(self, start, dir, 50, rocketSpeed, MZ2_CHICK_ROCKET_1);
 }
 
 void

--- a/src/monster/tank/tank.c
+++ b/src/monster/tank/tank.c
@@ -547,64 +547,26 @@ TankRocket(edict_t *self)
 
 	VectorNormalize(dir);
 
-	// Blindfire doesn't check target (done in checkattack). Paranoia:
-	// Make sure we're not shooting a target right next to us.
-	trace = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
-
 	if (blindfire)
 	{
-		// Blindfire has different fail criteria for the trace
-		if (!(trace.startsolid || trace.allsolid || (trace.fraction < 0.5)))
+		/* blindfire has different fail criteria for the trace */
+		if (!blind_rocket_ok(self, start, right, target, 20.0f, dir))
 		{
-			monster_fire_rocket (self, start, dir, 50, rocketSpeed, flash_number);
-		}
-		else
-		{
-			// Try shifting the target to the left a little (to help counter large offset)
-			VectorCopy(target, vec);
-			VectorMA(vec, -20, right, vec);
-			VectorSubtract(vec, start, dir);
-			VectorNormalize(dir);
-
-			trace = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
-
-			if (!(trace.startsolid || trace.allsolid || (trace.fraction < 0.5)))
-			{
-				monster_fire_rocket (self, start, dir, 50, rocketSpeed, flash_number);
-			}
-			else
-			{
-				// OK, that failed. Try to the right.
-				VectorCopy(target, vec);
-				VectorMA(vec, 20, right, vec);
-				VectorSubtract(vec, start, dir);
-				VectorNormalize(dir);
-
-				trace = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
-
-				if (!(trace.startsolid || trace.allsolid || (trace.fraction < 0.5)))
-				{
-					monster_fire_rocket (self, start, dir, 50, rocketSpeed, flash_number);
-				}
-				else if ((g_showlogic) && (g_showlogic->value))
-				{
-					gi.dprintf ("tank avoiding blindfire shot\n");
-				}
-			}
+			return;
 		}
 	}
 	else
 	{
 		trace = gi.trace(start, vec3_origin, vec3_origin, vec, self, MASK_SHOT);
 
-		if (trace.ent == self->enemy || trace.ent == world)
+		if (((trace.ent != self->enemy) && (trace.ent != world)) ||
+			((trace.fraction <= 0.5f) && !trace.ent->client))
 		{
-			if (trace.fraction > 0.5 || (trace.ent && trace.ent->client))
-			{
-				monster_fire_rocket (self, start, dir, 50, rocketSpeed, MZ2_CHICK_ROCKET_1);
-			}
+			return;
 		}
 	}
+
+	monster_fire_rocket (self, start, dir, 50, rocketSpeed, flash_number);
 }
 
 void


### PR DESCRIPTION
This PR addresses issue https://github.com/yquake2/rogue/issues/105

I also went ahead and did some optimizations. Rogue's code was doing an unnecessary trace for each non-blindfire rocket fired by tanks and chicks. I also ported over an older rewrite of this code I had done for my own project, as rogue's code was nasty and easy to mess up as rogue themselves demonstrated with this very bug.