### PR TITLE
Cheat to speed up "weapon change" animations

### DIFF
--- a/src/g_main.c
+++ b/src/g_main.c
@@ -76,6 +76,7 @@ cvar_t *g_disruptor;
 
 cvar_t *aimfix;
 cvar_t *g_machinegun_norecoil;
+cvar_t *g_swap_speed;
 
 void SpawnEntities(char *mapname, char *entities, char *spawnpoint);
 void ClientThink(edict_t *ent, usercmd_t *cmd);

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -635,6 +635,7 @@ extern cvar_t *g_disruptor;
 
 extern cvar_t *aimfix;
 extern cvar_t *g_machinegun_norecoil;
+extern cvar_t *g_swap_speed;
 
 /* this is for the count of monsters */
 #define ENT_SLOTS_LEFT \

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -585,6 +585,31 @@ Think_Weapon(edict_t *ent)
 }
 
 /*
+ * Client (player) animation for changing weapon
+ */
+static void
+Change_Weap_Animation(edict_t *ent)
+{
+	if (!ent)
+	{
+		return;
+	}
+
+	ent->client->anim_priority = ANIM_REVERSE;
+
+	if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
+	{
+		ent->s.frame = FRAME_crpain4 + 1;
+		ent->client->anim_end = FRAME_crpain1;
+	}
+	else
+	{
+		ent->s.frame = FRAME_pain304 + 1;
+		ent->client->anim_end = FRAME_pain301;
+	}
+}
+
+/*
  * Make the weapon ready if there is ammo
  */
 void
@@ -666,6 +691,7 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 		int FRAME_DEACTIVATE_LAST, int *pause_frames, int *fire_frames, void (*fire)(edict_t *ent))
 {
 	int n;
+	const unsigned short int change_speed = (g_swap_speed->value > 0)?(unsigned short int)g_swap_speed->value:1;
 
 	if (!ent || !fire)
 	{
@@ -684,23 +710,22 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 			ChangeWeapon(ent);
 			return;
 		}
-		else if ((FRAME_DEACTIVATE_LAST - ent->client->ps.gunframe) == 4)
+		else if ( (FRAME_DEACTIVATE_LAST - FRAME_DEACTIVATE_FIRST) >= (4 * change_speed) )
 		{
-			ent->client->anim_priority = ANIM_REVERSE;
-
-			if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
+			unsigned short int remainder = FRAME_DEACTIVATE_LAST - ent->client->ps.gunframe;
+			// "if (remainder == 4)" at change_speed == 1
+			if ( ( remainder <= (4 * change_speed) )
+				&& ( remainder > (3 * change_speed) ) )
 			{
-				ent->s.frame = FRAME_crpain4 + 1;
-				ent->client->anim_end = FRAME_crpain1;
-			}
-			else
-			{
-				ent->s.frame = FRAME_pain304 + 1;
-				ent->client->anim_end = FRAME_pain301;
+				Change_Weap_Animation(ent);
 			}
 		}
 
-		ent->client->ps.gunframe++;
+		ent->client->ps.gunframe += change_speed;
+		if (ent->client->ps.gunframe > FRAME_DEACTIVATE_LAST)
+		{
+			ent->client->ps.gunframe = FRAME_DEACTIVATE_LAST;
+		}
 		return;
 	}
 
@@ -713,7 +738,11 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 			return;
 		}
 
-		ent->client->ps.gunframe++;
+		ent->client->ps.gunframe += change_speed;
+		if (ent->client->ps.gunframe > FRAME_ACTIVATE_LAST)
+		{
+			ent->client->ps.gunframe = FRAME_ACTIVATE_LAST;
+		}
 		return;
 	}
 
@@ -722,20 +751,9 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 		ent->client->weaponstate = WEAPON_DROPPING;
 		ent->client->ps.gunframe = FRAME_DEACTIVATE_FIRST;
 
-		if ((FRAME_DEACTIVATE_LAST - FRAME_DEACTIVATE_FIRST) < 4)
+		if ( (FRAME_DEACTIVATE_LAST - FRAME_DEACTIVATE_FIRST) < (4 * change_speed) )
 		{
-			ent->client->anim_priority = ANIM_REVERSE;
-
-			if (ent->client->ps.pmove.pm_flags & PMF_DUCKED)
-			{
-				ent->s.frame = FRAME_crpain4 + 1;
-				ent->client->anim_end = FRAME_crpain1;
-			}
-			else
-			{
-				ent->s.frame = FRAME_pain304 + 1;
-				ent->client->anim_end = FRAME_pain301;
-			}
+			Change_Weap_Animation(ent);
 		}
 
 		return;

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -705,7 +705,7 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 
 	if (ent->client->weaponstate == WEAPON_DROPPING)
 	{
-		if (ent->client->ps.gunframe == FRAME_DEACTIVATE_LAST)
+		if (ent->client->ps.gunframe >= FRAME_DEACTIVATE_LAST - change_speed + 1)
 		{
 			ChangeWeapon(ent);
 			return;
@@ -722,16 +722,12 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 		}
 
 		ent->client->ps.gunframe += change_speed;
-		if (ent->client->ps.gunframe > FRAME_DEACTIVATE_LAST)
-		{
-			ent->client->ps.gunframe = FRAME_DEACTIVATE_LAST;
-		}
 		return;
 	}
 
 	if (ent->client->weaponstate == WEAPON_ACTIVATING)
 	{
-		if (ent->client->ps.gunframe == FRAME_ACTIVATE_LAST)
+		if (ent->client->ps.gunframe >= FRAME_ACTIVATE_LAST - change_speed + 1)
 		{
 			ent->client->weaponstate = WEAPON_READY;
 			ent->client->ps.gunframe = FRAME_IDLE_FIRST;
@@ -739,10 +735,6 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 		}
 
 		ent->client->ps.gunframe += change_speed;
-		if (ent->client->ps.gunframe > FRAME_ACTIVATE_LAST)
-		{
-			ent->client->ps.gunframe = FRAME_ACTIVATE_LAST;
-		}
 		return;
 	}
 

--- a/src/savegame/savegame.c
+++ b/src/savegame/savegame.c
@@ -260,6 +260,7 @@ InitGame(void)
 	/* others */
 	aimfix = gi.cvar("aimfix", "0", CVAR_ARCHIVE);
 	g_machinegun_norecoil = gi.cvar("g_machinegun_norecoil", "0", CVAR_ARCHIVE);
+	g_swap_speed = gi.cvar("g_swap_speed", "1", 0);
 
 	/* items */
 	InitItems ();


### PR DESCRIPTION
Rogue version of https://github.com/yquake2/yquake2/pull/1031
Allows to skip frames of "putting down weapon" and "raising weapon" animations, speeding them up.