### PR TITLE
Fixed gunner grenade duck code running twice

### DIFF
--- a/src/monster/gunner/gunner.c
+++ b/src/monster/gunner/gunner.c
@@ -509,14 +509,6 @@ gunner_duck_down(edict_t *self)
 
 	self->monsterinfo.aiflags |= AI_DUCKED;
 
-	if (skill->value >= SKILL_HARD)
-	{
-		if (random() > 0.5)
-		{
-			GunnerGrenade(self);
-		}
-	}
-
 	self->maxs[2] = self->monsterinfo.base_height - 32;
 	self->takedamage = DAMAGE_YES;
 
@@ -528,8 +520,23 @@ gunner_duck_down(edict_t *self)
 	gi.linkentity(self);
 }
 
+static void
+gunner_duck_down_think(edict_t *self)
+{
+	gunner_duck_down(self);
+
+	/* rogue code calls duck_down twice, so move this here */
+	if (skill->value >= SKILL_HARD)
+	{
+		if (random() > 0.5)
+		{
+			GunnerGrenade(self);
+		}
+	}
+}
+
 mframe_t gunner_frames_duck[] = {
-	{ai_move, 1, gunner_duck_down},
+	{ai_move, 1, gunner_duck_down_think},
 	{ai_move, 1, NULL},
 	{ai_move, 1, monster_duck_hold},
 	{ai_move, 0, NULL},


### PR DESCRIPTION
This PR fixes issue https://github.com/yquake2/rogue/issues/111.

Rogue's ducking code is messy and inefficient. I opted not to touch it and just do the simplest fix possible, any rewrites and optimizations can be done later if desired.

I created a new function for the Gunner duck frames and moved the grenade throwing stuff in there. This guarantees he will only throw a grenade once at the start of the ducking move like intended.