### PR TITLE
Apply changes from recent original Xatrix GPL release

### DIFF
--- a/src/dm/ball.c
+++ b/src/dm/ball.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Deathmatch ball.

--- a/src/dm/tag.c
+++ b/src/dm/tag.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Deathmatch tag.

--- a/src/g_ai.c
+++ b/src/g_ai.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * The basic AI functions like enemy detection, attacking and so on.

--- a/src/g_chase.c
+++ b/src/g_chase.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_cmds.c
+++ b/src/g_cmds.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Game command processing.

--- a/src/g_combat.c
+++ b/src/g_combat.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_func.c
+++ b/src/g_func.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_items.c
+++ b/src/g_items.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *
@@ -38,11 +40,11 @@ gitem_armor_t jacketarmor_info = {25, 50, .30, .00, ARMOR_JACKET};
 gitem_armor_t combatarmor_info = {50, 100, .60, .30, ARMOR_COMBAT};
 gitem_armor_t bodyarmor_info = {100, 200, .80, .60, ARMOR_BODY};
 
-int jacket_armor_index;
-int combat_armor_index;
-int body_armor_index;
-static int power_screen_index;
-static int power_shield_index;
+static int	jacket_armor_index;
+static int	combat_armor_index;
+static int	body_armor_index;
+static int	power_screen_index;
+static int	power_shield_index;
 
 void Use_Quad(edict_t *ent, gitem_t *item);
 static int quad_drop_timeout_hack;

--- a/src/g_main.c
+++ b/src/g_main.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_monster.c
+++ b/src/g_monster.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_newai.c
+++ b/src/g_newai.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_newdm.c
+++ b/src/g_newdm.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_newfnc.c
+++ b/src/g_newfnc.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_newtarg.c
+++ b/src/g_newtarg.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_newtrig.c
+++ b/src/g_newtrig.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_phys.c
+++ b/src/g_phys.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Quake IIs legendary physic engine.

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_sphere.c
+++ b/src/g_sphere.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * =======================================================================
  *

--- a/src/g_svcmds.c
+++ b/src/g_svcmds.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Game side of server CMDs. At this time only the ipfilter.

--- a/src/g_target.c
+++ b/src/g_target.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Targets.

--- a/src/g_trigger.c
+++ b/src/g_trigger.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Trigger.

--- a/src/g_turret.c
+++ b/src/g_turret.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Turrets aka big cannons with a driver.

--- a/src/g_utils.c
+++ b/src/g_utils.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Misc. utility functions for the game logic.

--- a/src/g_weapon.c
+++ b/src/g_weapon.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Weapon support functions.

--- a/src/header/game.h
+++ b/src/header/game.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Here are the client, server and game are tied together.

--- a/src/header/local.h
+++ b/src/header/local.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Main header file for the game module.

--- a/src/monster/berserker/berserker.c
+++ b/src/monster/berserker/berserker.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * The berserker.

--- a/src/monster/berserker/berserker.h
+++ b/src/monster/berserker/berserker.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Berserker animations.

--- a/src/monster/boss2/boss2.c
+++ b/src/monster/boss2/boss2.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Boss 2 aka Hornet.

--- a/src/monster/boss2/boss2.h
+++ b/src/monster/boss2/boss2.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Animations for boss2.

--- a/src/monster/boss3/boss3.c
+++ b/src/monster/boss3/boss3.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 #include "../../header/local.h"
 #include "boss32.h"
 

--- a/src/monster/boss3/boss31.c
+++ b/src/monster/boss3/boss31.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Final boss, stage 1 (jorg).

--- a/src/monster/boss3/boss31.h
+++ b/src/monster/boss3/boss31.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Animations for final boss stage 1.

--- a/src/monster/boss3/boss32.c
+++ b/src/monster/boss3/boss32.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Final boss, stage 2 (makron).

--- a/src/monster/boss3/boss32.h
+++ b/src/monster/boss3/boss32.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Final boss, stage 2 (makron).

--- a/src/monster/brain/brain.c
+++ b/src/monster/brain/brain.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Brain.

--- a/src/monster/brain/brain.h
+++ b/src/monster/brain/brain.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Brain animations.

--- a/src/monster/carrier/carrier.c
+++ b/src/monster/carrier/carrier.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /*
  * ==============================================================================
  *

--- a/src/monster/carrier/carrier.h
+++ b/src/monster/carrier/carrier.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Carrier animations.

--- a/src/monster/chick/chick.c
+++ b/src/monster/chick/chick.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Iron Maiden.

--- a/src/monster/chick/chick.h
+++ b/src/monster/chick/chick.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Iron Maiden animations.

--- a/src/monster/flipper/flipper.c
+++ b/src/monster/flipper/flipper.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Baracuda Shark.

--- a/src/monster/flipper/flipper.h
+++ b/src/monster/flipper/flipper.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Baracuda Shark animations.

--- a/src/monster/float/float.c
+++ b/src/monster/float/float.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Mechanic.

--- a/src/monster/float/float.h
+++ b/src/monster/float/float.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Mechanic animations.

--- a/src/monster/flyer/flyer.c
+++ b/src/monster/flyer/flyer.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Flyer.

--- a/src/monster/flyer/flyer.h
+++ b/src/monster/flyer/flyer.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Flyer animations.

--- a/src/monster/gladiator/gladiator.c
+++ b/src/monster/gladiator/gladiator.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Gladiator.

--- a/src/monster/gladiator/gladiator.h
+++ b/src/monster/gladiator/gladiator.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Gladiator animations.

--- a/src/monster/gunner/gunner.c
+++ b/src/monster/gunner/gunner.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Gunner.

--- a/src/monster/gunner/gunner.h
+++ b/src/monster/gunner/gunner.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Gunner animations.

--- a/src/monster/hover/hover.c
+++ b/src/monster/hover/hover.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Icarus and Daedalus.

--- a/src/monster/hover/hover.h
+++ b/src/monster/hover/hover.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Icarus and Daedalus animations.

--- a/src/monster/infantry/infantry.c
+++ b/src/monster/infantry/infantry.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Infantry.

--- a/src/monster/infantry/infantry.h
+++ b/src/monster/infantry/infantry.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Infantry animations.

--- a/src/monster/insane/insane.c
+++ b/src/monster/insane/insane.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * The insane earth soldiers.

--- a/src/monster/insane/insane.h
+++ b/src/monster/insane/insane.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Insane animations

--- a/src/monster/medic/medic.c
+++ b/src/monster/medic/medic.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Medic and Medic commander.

--- a/src/monster/medic/medic.h
+++ b/src/monster/medic/medic.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Medic and Medic Commander animations.

--- a/src/monster/misc/move.c
+++ b/src/monster/misc/move.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Monster movement support functions.

--- a/src/monster/misc/player.h
+++ b/src/monster/misc/player.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Player (the arm and the weapons) animation.

--- a/src/monster/mutant/mutant.c
+++ b/src/monster/mutant/mutant.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Mutant.

--- a/src/monster/mutant/mutant.h
+++ b/src/monster/mutant/mutant.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Mutant animations.

--- a/src/monster/parasite/parasite.c
+++ b/src/monster/parasite/parasite.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Parasite.

--- a/src/monster/parasite/parasite.h
+++ b/src/monster/parasite/parasite.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Parasite animations.

--- a/src/monster/soldier/soldier.c
+++ b/src/monster/soldier/soldier.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Soldier aka "Guard". This is the most complex enemy in Quake 2, since

--- a/src/monster/soldier/soldier.h
+++ b/src/monster/soldier/soldier.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Soldier aka "Guard" animations.

--- a/src/monster/stalker/stalker.c
+++ b/src/monster/stalker/stalker.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Stalker.

--- a/src/monster/stalker/stalker.h
+++ b/src/monster/stalker/stalker.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Stalker animations.

--- a/src/monster/supertank/supertank.c
+++ b/src/monster/supertank/supertank.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Supertank aka "Boss1".

--- a/src/monster/supertank/supertank.h
+++ b/src/monster/supertank/supertank.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Supertank aka "Boss1" animations.

--- a/src/monster/tank/tank.c
+++ b/src/monster/tank/tank.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Tank and Tank Commander.

--- a/src/monster/tank/tank.h
+++ b/src/monster/tank/tank.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Tank and Tank Commander animations.

--- a/src/monster/turret/turret.c
+++ b/src/monster/turret/turret.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Wall mounted turrets.

--- a/src/monster/turret/turret.h
+++ b/src/monster/turret/turret.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Turret animations.

--- a/src/monster/widow/widow.c
+++ b/src/monster/widow/widow.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Black Window (stage 1).

--- a/src/monster/widow/widow.h
+++ b/src/monster/widow/widow.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Black Widow (stage 1) animations.

--- a/src/monster/widow/widow2.c
+++ b/src/monster/widow/widow2.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Black Window (stage 2).

--- a/src/monster/widow/widow2.h
+++ b/src/monster/widow/widow2.h
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Black Widow (stage 2) animations.

--- a/src/player/client.c
+++ b/src/player/client.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Interface between client <-> game and client calculations.

--- a/src/player/hud.c
+++ b/src/player/hud.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * HUD, deathmatch scoreboard, help computer and intermission stuff.

--- a/src/player/trail.c
+++ b/src/player/trail.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * The player trail, used by monsters to locate the player.

--- a/src/player/view.c
+++ b/src/player/view.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * The "camera" through that the player looks into the game.

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -1,3 +1,5 @@
+// Copyright (c) ZeniMax Media Inc.
+// Licensed under the GNU General Public License 2.0.
 /* =======================================================================
  *
  * Player weapons.


### PR DESCRIPTION
With the freshly released Quake 2 Remaster game DLL sources (https://github.com/id-Software/quake2-rerelease-dll) comes a GPLed release of the original rogue source code.
This changes includes all changes that are present there, but were not present in the sources this repo was originally based on.

Practically, this boils down to mostly copyright notices.
The most exciting other changes are the `static` additions in `g_items.c`.