### PR TITLE
Fix minor AI glitches with turrets

### DIFF
--- a/src/monster/turret/turret.c
+++ b/src/monster/turret/turret.c
@@ -887,6 +887,7 @@ turret_wake(edict_t *self)
 	self->monsterinfo.sight = turret_sight;
 	self->monsterinfo.search = turret_search;
 	self->monsterinfo.currentmove = &turret_move_stand;
+
 	self->takedamage = DAMAGE_AIM;
 	self->movetype = MOVETYPE_NONE;
 	self->monsterinfo.aiflags |= AI_DO_NOT_COUNT;
@@ -894,6 +895,11 @@ turret_wake(edict_t *self)
 	gi.linkentity(self);
 
 	stationarymonster_start(self);
+
+	if (self->think)
+	{
+		self->think(self);
+	}
 
 	if (self->spawnflags & SPAWN_MACHINEGUN)
 	{
@@ -914,6 +920,11 @@ turret_activate(edict_t *self, edict_t *other, edict_t *activator)
 	vec3_t endpos;
 	vec3_t forward;
 	edict_t *base;
+
+	if (self->movetype == MOVETYPE_PUSH)
+	{
+		return;
+	}
 
 	self->movetype = MOVETYPE_PUSH;
 
@@ -949,6 +960,10 @@ turret_activate(edict_t *self, edict_t *other, edict_t *activator)
 	else if (self->s.angles[1] == 270)
 	{
 		VectorSet(forward, 0, -1, 0);
+	}
+	else
+	{
+		VectorClear(forward);
 	}
 
 	/* start up the turret */


### PR DESCRIPTION
This PR addresses issues in https://github.com/yquake2/rogue/issues/116.

First issue was caused by turret activation taking 2 frames. First it calls stationarymonster_start, then stationarymonster_start_go when it thinks next time. If you deal damage before the 2nd call, that call will override the run frames back to stand frames whuch don't checkattack (unless the monster stands ground). I fixed this simply by calling the think function early, so that the activation finishes in 1 frame.

The 2nd issue is both a map bug and a code bug.  The map bug is that the trigger that activates the turrets is a trigger_multiple that has no cooldown, meaning fast repeated activations. The code bug is that there is no protection against duplicate activation for turrets. I will maybe do a mapfix at some point, but here I address the code issue by adding a check for whether the turret is already in the process of activating.

EDIT: Oh and I spotted in turret_activate that the forward vector can be used uninitialized if the turret's angles are badly set by the map, so I added a VectorClear as the else case.