### PR TITLE
Fix for g_swap_speed behaviour with extreme values

### DIFF
--- a/CHANGELOG
+++ b/CHANGELOG
@@ -5,7 +5,7 @@ Ground Zero 2.09 to 2.10
   a player standing on a blocked elevator gets turned around (by
   skuller).
 - Fix several coop related bugs with the powercubes. (by BjossiAlfreds)
-- A way better fix for dead bodys obstructing elevators or falling
+- A way better fix for dead bodies obstructing elevators or falling
   through the worldmodel. (by BjossiAlfreds)
 - Fix items already in water playing a splash sound at level start. (by
   BjossiAlfreds)

--- a/Makefile
+++ b/Makefile
@@ -6,8 +6,8 @@
 #                                                       #
 # Dependencies:                                         #
 # - None, but you need a Quake II to play.              #
-#   While in theorie every client should work           #
-#   Yamagi Quake II ist recommended.                    #
+#   While in theory every client should work            #
+#   Yamagi Quake II is recommended.                     #
 #                                                       #
 # Platforms:                                            #
 # - FreeBSD                                             #
@@ -286,7 +286,7 @@ ROGUE_OBJS_ = \
 
 # ----------
 
-# Rewrite pathes to our object directory
+# Rewrite paths to our object directory
 ROGUE_OBJS = $(patsubst %,build/%,$(ROGUE_OBJS_))
 
 # ----------

--- a/src/g_misc.c
+++ b/src/g_misc.c
@@ -697,7 +697,7 @@ SP_info_null(edict_t *self)
 /*
  * QUAKED info_notnull (0 0.5 0) (-4 -4 -4) (4 4 4)
  *
- * Used as a positional target for lightning.
+ * Used as a positional target for lighting.
  */
 void
 SP_info_notnull(edict_t *self)

--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -691,7 +691,9 @@ Weapon_Generic(edict_t *ent, int FRAME_ACTIVATE_LAST, int FRAME_FIRE_LAST, int F
 		int FRAME_DEACTIVATE_LAST, int *pause_frames, int *fire_frames, void (*fire)(edict_t *ent))
 {
 	int n;
-	const unsigned short int change_speed = (g_swap_speed->value > 0)?(unsigned short int)g_swap_speed->value:1;
+	const unsigned short int change_speed = (g_swap_speed->value > 1)?
+		(g_swap_speed->value < USHRT_MAX)? (unsigned short int)g_swap_speed->value : 1
+		: 1;
 
 	if (!ent || !fire)
 	{


### PR DESCRIPTION
Rogue version of https://github.com/yquake2/yquake2/pull/1049
Weapon animation gets stuck with a cvar value between 0 and 1, or if it exceeds 65535.