### PR TITLE
Fix Entity used itself in rbase1 and other minor fixes

### DIFF
--- a/stuff/mapfixes/rbase1.ent
+++ b/stuff/mapfixes/rbase1.ent
@@ -1,0 +1,5423 @@
+// FIXED ENTITY STRING (by BjossiAlfreds)
+//
+// 1. Fixed "WARNING: Entity used itself."
+//    appearing during gameplay (b#1)
+//
+// A trigger_once that targets some monsters
+// also targets itself for some reason.
+//
+// 2. Fixed old classnames (b#2)
+//
+// 3. Fixed wrong/overlapping secret sound effects (b#3)
+//
+// 4. Added missing targetname to target_explosion (b#4)
+{
+"sounds" "10"
+"message" "Logistics Complex"
+"nextmap" "rbase2"
+"sky" "rogue1"
+"classname" "worldspawn"
+}
+{
+"classname" "misc_teleporter_dest"
+"spawnflags" "5888"
+"angle" "180"
+"targetname" "t221"
+"origin" "-1120 1216 216"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "5888"
+"target" "t221"
+"origin" "2560 128 -296"
+}
+{
+"classname" "misc_teleporter_dest"
+"spawnflags" "5888"
+"angle" "270"
+"targetname" "t220"
+"origin" "-2144 2336 -232"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "5888"
+"target" "t220"
+"origin" "1984 1792 24"
+}
+{
+"model" "*1"
+"message" "Doors locked."
+"wait" "4"
+"targetname" "t218"
+"spawnflags" "2052"
+"classname" "trigger_multiple"
+}
+{
+"model" "*2"
+"wait" "4"
+"target" "t219"
+"targetname" "t218"
+"spawnflags" "2052"
+"classname" "trigger_multiple"
+}
+{
+"killtarget" "4idiots"
+"target" "t218"
+"origin" "2184 128 -208"
+"targetname" "t39"
+"spawnflags" "2048"
+"classname" "trigger_relay"
+}
+{
+"classname" "item_sphere_vengeance"
+"spawnflags" "5888"
+"origin" "-416 -32 -496"
+}
+{
+"classname" "ammo_cells"
+"origin" "176 64 -496"
+}
+{
+"classname" "ammo_cells"
+"origin" "-264 -32 -496"
+}
+{
+"classname" "weapon_plasmabeam"
+"spawnflags" "5888"
+"origin" "0 128 -496"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_shells"
+"origin" "2272 -40 -304"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "5888"
+"origin" "2280 360 -304"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "5888"
+"origin" "2272 128 -304"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "225"
+"origin" "1504 416 -296"
+}
+{
+"classname" "weapon_etf_rifle"
+"spawnflags" "5888"
+"origin" "1392 336 -296"
+}
+{
+"classname" "ammo_flechettes"
+"spawnflags" "5888"
+"origin" "1360 400 -296"
+}
+{
+"classname" "ammo_shells"
+"spawnflags" "5888"
+"origin" "-1440 2216 -240"
+}
+{
+"classname" "weapon_supershotgun"
+"spawnflags" "5888"
+"origin" "-1504 2200 -240"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "1504 -224 -296"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_rockets"
+"origin" "1592 -96 -496"
+}
+{
+"classname" "ammo_rockets"
+"spawnflags" "5888"
+"origin" "1216 -80 -496"
+}
+{
+"classname" "weapon_rocketlauncher"
+"origin" "1408 -72 -496"
+"spawnflags" "5888"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_prox"
+"origin" "-224 448 -304"
+}
+{
+"classname" "ammo_prox"
+"spawnflags" "5888"
+"origin" "160 536 -304"
+}
+{
+"classname" "weapon_proxlauncher"
+"spawnflags" "5888"
+"origin" "0 376 -304"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "0 -168 -488"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "45"
+"spawnflags" "5888"
+"origin" "-1248 456 -232"
+}
+{
+"classname" "misc_teleporter"
+"spawnflags" "5888"
+"target" "t217"
+"origin" "928 72 -232"
+}
+{
+"classname" "misc_teleporter_dest"
+"spawnflags" "5888"
+"origin" "-672 760 24"
+"targetname" "t217"
+"angle" "90"
+}
+{
+"classname" "item_double"
+"spawnflags" "5888"
+"origin" "-672 840 24"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_cells"
+"origin" "-664 1576 -240"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "5888"
+"origin" "-832 912 -240"
+}
+{
+"classname" "weapon_hyperblaster"
+"spawnflags" "5888"
+"origin" "-680 1256 -240"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "1096 1464 -8"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "135"
+"origin" "1568 1672 24"
+}
+{
+"angle" "315"
+"classname" "info_player_deathmatch"
+"origin" "-840 1696 -232"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-384 888 -232"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-1696 1368 -232"
+}
+{
+"classname" "item_sphere_defender"
+"spawnflags" "5888"
+"origin" "-1760 1312 16"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-1760 1472 24"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-1024 1216 24"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_cells"
+"origin" "-1048 1320 208"
+}
+{
+"classname" "ammo_cells"
+"spawnflags" "5888"
+"origin" "-992 1880 112"
+}
+{
+"classname" "weapon_plasmabeam"
+"spawnflags" "5888"
+"origin" "-1208 1192 208"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-1856 1696 24"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "0"
+"origin" "-2432 2080 -232"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-1696 1688 -232"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "-1184 2048 -40"
+}
+{
+"classname" "weapon_rocketlauncher"
+"spawnflags" "5888"
+"origin" "-560 1696 16"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_rockets"
+"origin" "-680 1680 16"
+}
+{
+"classname" "weapon_chaingun"
+"spawnflags" "5888"
+"origin" "1312 1824 16"
+}
+{
+"spawnflags" "5888"
+"classname" "ammo_bullets"
+"origin" "1248 1768 16"
+}
+{
+"classname" "ammo_bullets"
+"spawnflags" "5888"
+"origin" "1632 2048 16"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "180"
+"origin" "1632 2208 24"
+}
+{
+"classname" "info_player_deathmatch"
+"angle" "90"
+"origin" "1848 -120 -296"
+}
+{
+"classname" "ammo_nuke"
+"spawnflags" "5888"
+"origin" "1024 376 -504"
+}
+{
+"model" "*3"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*4"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"target" "t216"
+"targetname" "t215"
+"origin" "-1472 1216 208"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t215"
+"targetname" "t214"
+"origin" "-1472 1560 208"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t214"
+"targetname" "t213"
+"origin" "-1472 1856 208"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t213"
+"targetname" "t212"
+"origin" "-1256 1856 208"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t212"
+"targetname" "t211"
+"origin" "-1024 1856 112"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t211"
+"targetname" "t210"
+"origin" "-1024 1712 64"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t210"
+"targetname" "t209"
+"origin" "-1056 1472 16"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t209"
+"targetname" "t208"
+"origin" "-1296 1472 16"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t208"
+"targetname" "t207"
+"origin" "-1472 1472 16"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t207"
+"origin" "-1616 1480 16"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"target" "t205"
+"targetname" "t204"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1856 1792 16"
+}
+{
+"target" "t206"
+"targetname" "t205"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1664 1792 16"
+}
+{
+"targetname" "t206"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-1664 1544 16"
+}
+{
+"target" "t204"
+"origin" "-2304 1792 16"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"targetname" "t203"
+"origin" "-1664 1408 16"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"target" "t203"
+"targetname" "t202"
+"origin" "-1664 1216 -48"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"targetname" "t216"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-1216 1216 208"
+}
+{
+"target" "t201"
+"targetname" "t200"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1944 1208 -128"
+}
+{
+"target" "t200"
+"targetname" "t199"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-2056 1344 -176"
+}
+{
+"target" "t199"
+"targetname" "t198"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1944 1472 -224"
+}
+{
+"target" "t198"
+"targetname" "t197"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1664 1472 -240"
+}
+{
+"target" "t197"
+"targetname" "t196"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1472 1408 -240"
+}
+{
+"target" "t196"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-1192 1408 -240"
+}
+{
+"targetname" "t195"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-1152 1472 -240"
+}
+{
+"target" "t195"
+"targetname" "t194"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1152 1792 -240"
+}
+{
+"target" "t194"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-1408 1792 -240"
+}
+{
+"target" "t193"
+"targetname" "t192"
+"origin" "-584 2056 16"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t192"
+"targetname" "t191"
+"origin" "-960 2048 16"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t191"
+"targetname" "t190"
+"origin" "-960 2176 16"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t190"
+"targetname" "t189"
+"origin" "-1256 2144 -48"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t189"
+"targetname" "t188"
+"origin" "-1472 2144 -240"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t188"
+"origin" "-1472 1832 -240"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"targetname" "t193"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-576 1728 16"
+}
+{
+"targetname" "t187"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-1536 1792 -240"
+}
+{
+"target" "t187"
+"targetname" "t186"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-1856 1792 -240"
+}
+{
+"target" "t186"
+"targetname" "t185"
+"origin" "-2224 1792 -240"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t185"
+"origin" "-2144 2088 -240"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"target" "t202"
+"targetname" "t201"
+"origin" "-1792 1216 -48"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"origin" "1536 -448 -456"
+"target" "t184"
+"targetname" "t183"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"origin" "1408 -528 -432"
+"target" "t183"
+"targetname" "t182"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"origin" "1304 -456 -400"
+"target" "t182"
+"targetname" "t181"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"origin" "1280 -184 -304"
+"target" "t181"
+"targetname" "t180"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"origin" "1536 -200 -496"
+"targetname" "t184"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "1408 -40 -304"
+"targetname" "t179"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "1408 256 -304"
+"target" "t179"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "1408 -88 -304"
+"target" "t180"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"origin" "1088 -64 -304"
+"targetname" "t178"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "1368 -64 -304"
+"target" "t178"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"target" "t174"
+"targetname" "t173"
+"origin" "1856 512 -304"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t175"
+"targetname" "t174"
+"origin" "1696 640 -304"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t176"
+"targetname" "t175"
+"origin" "1216 640 -304"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t177"
+"targetname" "t176"
+"origin" "960 576 -304"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"targetname" "t177"
+"origin" "896 256 -304"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"target" "t173"
+"origin" "1856 256 -304"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"origin" "384 408 -304"
+"target" "t171"
+"targetname" "t170"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "400 104 -304"
+"target" "t172"
+"targetname" "t171"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "624 96 -304"
+"targetname" "t172"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "-48 424 -304"
+"target" "t170"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"target" "t169"
+"targetname" "t168"
+"origin" "688 568 -424"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t168"
+"targetname" "t167"
+"origin" "248 560 -496"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t167"
+"origin" "32 560 -496"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"targetname" "t166"
+"spawnflags" "2049"
+"classname" "hint_path"
+"origin" "0 512 -496"
+}
+{
+"targetname" "t169"
+"spawnflags" "2049"
+"classname" "hint_path"
+"origin" "696 192 -304"
+}
+{
+"targetname" "t165"
+"spawnflags" "2049"
+"classname" "hint_path"
+"origin" "-24 560 -496"
+}
+{
+"target" "t165"
+"targetname" "t164"
+"origin" "-200 560 -496"
+"spawnflags" "2048"
+"classname" "hint_path"
+}
+{
+"target" "t164"
+"origin" "-416 512 -496"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"origin" "-488 152 -496"
+"target" "t163"
+"targetname" "t162"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "-416 416 -496"
+"targetname" "t163"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"target" "t166"
+"origin" "0 216 -496"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "-800 512 -240"
+"targetname" "t161"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "-1216 512 -240"
+"target" "t161"
+"targetname" "t160"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "-1152 832 -240"
+"target" "t160"
+"targetname" "t159"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "-1152 1184 -240"
+"target" "t159"
+"targetname" "t158"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "-1152 1352 -240"
+"target" "t158"
+"classname" "hint_path"
+"spawnflags" "2049"
+}
+{
+"origin" "-424 -32 -496"
+"target" "t162"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"classname" "info_player_intermission"
+"angles" "10 135 0"
+"origin" "-128 1000 88"
+"spawnflags" "0"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "6945"
+"angle" "0"
+"origin" "-1720 1792 -96"
+}
+{
+"angle" "0"
+"spawnflags" "7177"
+"classname" "monster_turret"
+"origin" "520 576 -344"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "2016 1792 160"
+}
+{
+"origin" "-672 1728 24"
+"message" "Return and collect\n data disk."
+"targetname" "t12"
+"spawnflags" "2048"
+"classname" "target_help"
+}
+{
+"origin" "-1432 1664 280"
+"angle" "0"
+"spawnflags" "3841"
+"classname" "monster_daedalus"
+}
+{
+"origin" "-1624 1176 164"
+"targetname" "t126"
+"angle" "-2"
+"spawnflags" "4001"
+"classname" "monster_turret"
+}
+{
+"origin" "-1968 1464 -40"
+"angle" "180"
+"target" "t126"
+"item" "ammo_cells"
+"spawnflags" "6913"
+"classname" "monster_daedalus"
+}
+{
+"angle" "-2"
+"origin" "-1440 1376 -72"
+"spawnflags" "2057"
+"classname" "monster_turret"
+}
+{
+"item" "ammo_grenades"
+"classname" "monster_gunner"
+"angle" "180"
+"spawnflags" "6913"
+"origin" "-1304 2144 -224"
+}
+{
+"targetname" "t118"
+"classname" "monster_turret"
+"angle" "-2"
+"spawnflags" "7073"
+"origin" "-1568 2080 100"
+}
+{
+"origin" "-1928 1832 -224"
+"targetname" "t113"
+"target" "t115"
+"angle" "180"
+"spawnflags" "3841"
+"classname" "monster_gunner"
+}
+{
+"origin" "-2048 1760 -80"
+"spawnflags" "3841"
+"angle" "90"
+"classname" "monster_daedalus"
+}
+{
+"origin" "1488 400 -288"
+"angle" "270"
+"spawnflags" "3841"
+"target" "t141"
+"item" "ammo_slugs"
+"classname" "monster_gladiator"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "6945"
+"origin" "1408 32 -136"
+"angle" "-2"
+}
+{
+"item" "ammo_grenades"
+"origin" "1216 -80 -480"
+"angle" "45"
+"classname" "monster_gunner"
+"spawnflags" "6913"
+}
+{
+"classname" "monster_turret"
+"angle" "270"
+"spawnflags" "6945"
+"origin" "1408 128 -424"
+}
+{
+"item" "ammo_grenades"
+"origin" "472 344 -288"
+"spawnflags" "6913"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "872 648 -80"
+"angle" "270"
+"spawnflags" "3841"
+"classname" "monster_daedalus"
+}
+{
+"origin" "872 648 -80"
+"angle" "270"
+"spawnflags" "6913"
+"classname" "monster_hover"
+}
+{
+"angle" "90"
+"target" "t65"
+"spawnflags" "3841"
+"origin" "656 -136 -288"
+"classname" "monster_gladiator"
+}
+{
+"origin" "712 616 -424"
+"classname" "item_health"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "3873"
+"angle" "0"
+"origin" "520 576 -344"
+}
+{
+"origin" "-384 -32 -480"
+"spawnflags" "2049"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"origin" "-344 40 -480"
+"classname" "ammo_cells"
+}
+{
+"origin" "-552 416 -480"
+"item" "ammo_shells"
+"spawnflags" "6401"
+"angle" "45"
+"classname" "monster_soldier"
+}
+{
+"origin" "-928 608 -224"
+"angle" "270"
+"spawnflags" "6913"
+"classname" "monster_gunner"
+}
+{
+"targetname" "t61"
+"classname" "monster_turret"
+"angle" "-2"
+"spawnflags" "4001"
+"origin" "-1152 608 -28"
+}
+{
+"origin" "-1056 1056 -28"
+"targetname" "t60"
+"angle" "-2"
+"spawnflags" "3985"
+"classname" "monster_turret"
+}
+{
+"targetname" "t157"
+"classname" "hint_path"
+"spawnflags" "2049"
+"origin" "-560 976 -240"
+}
+{
+"target" "t157"
+"targetname" "t156"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-568 1264 -280"
+}
+{
+"target" "t156"
+"targetname" "t155"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-280 1224 -304"
+}
+{
+"target" "t155"
+"targetname" "t154"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "112 968 -264"
+}
+{
+"target" "t154"
+"targetname" "t153"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "136 1144 -232"
+}
+{
+"target" "t153"
+"targetname" "t152"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-40 1280 -184"
+}
+{
+"target" "t152"
+"targetname" "t151"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "-104 1544 -104"
+}
+{
+"target" "t151"
+"targetname" "t150"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "104 1752 -64"
+}
+{
+"target" "t147"
+"targetname" "t146"
+"spawnflags" "2048"
+"classname" "hint_path"
+"origin" "872 1304 -8"
+}
+{
+"target" "t148"
+"targetname" "t147"
+"spawnflags" "2048"
+"classname" "hint_path"
+"origin" "648 1440 -8"
+}
+{
+"target" "t150"
+"targetname" "t149"
+"classname" "hint_path"
+"spawnflags" "2048"
+"origin" "456 1864 -64"
+}
+{
+"target" "t149"
+"targetname" "t148"
+"origin" "656 1760 -24"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"target" "t146"
+"targetname" "t145"
+"origin" "1040 1472 -8"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "1104 1736 -24"
+"target" "t145"
+"targetname" "t144"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "1264 2032 -48"
+"target" "t144"
+"targetname" "t143"
+"classname" "hint_path"
+"spawnflags" "2048"
+}
+{
+"origin" "1472 1856 16"
+"target" "t143"
+"spawnflags" "2049"
+"classname" "hint_path"
+}
+{
+"origin" "1536 2232 328"
+"item" "ammo_cells"
+"angle" "270"
+"spawnflags" "3841"
+"classname" "monster_daedalus"
+}
+{
+"classname" "monster_daedalus"
+"spawnflags" "6913"
+"angle" "270"
+"item" "ammo_cells"
+"origin" "1496 2232 328"
+}
+{
+"origin" "-2048 2208 -204"
+"classname" "light"
+"light" "50"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "-2240 2208 -204"
+"_color" "1.000000 0.000000 0.000000"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "2424 228 -268"
+"classname" "light"
+"light" "50"
+"_color" "1.000000 0.000000 0.000000"
+}
+{
+"origin" "2424 28 -268"
+"_color" "1.000000 0.000000 0.000000"
+"light" "50"
+"classname" "light"
+}
+{
+"classname" "target_goal"
+"spawnflags" "2048"
+"targetname" "t142"
+"origin" "-1216 1640 104"
+}
+{
+"spawnflags" "2048"
+"classname" "target_goal"
+"targetname" "t140"
+"origin" "0 184 -368"
+}
+{
+"classname" "item_armor_body"
+"origin" "-1280 1144 24"
+}
+{
+"classname" "monster_soldier_ss"
+"spawnflags" "2049"
+"item" "ammo_bullets"
+"angle" "180"
+"origin" "1640 168 -288"
+}
+{
+"classname" "monster_soldier"
+"origin" "1480 392 -296"
+"spawnflags" "7681"
+"item" "ammo_shells"
+"target" "t141"
+"angle" "270"
+}
+{
+"classname" "monster_gunner"
+"origin" "1496 408 -296"
+"spawnflags" "7425"
+"item" "ammo_grenades"
+"target" "t141"
+"angle" "270"
+}
+{
+"classname" "monster_gladiator"
+"angle" "270"
+"spawnflags" "6913"
+"origin" "1488 400 -288"
+"item" "ammo_slugs"
+"target" "t141"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2049"
+"origin" "1408 96 -304"
+"targetname" "t141"
+}
+{
+"spawnflags" "2337"
+"angle" "-2"
+"classname" "monster_turret"
+"origin" "1640 224 -136"
+}
+{
+"classname" "monster_turret"
+"angle" "-2"
+"spawnflags" "3593"
+"origin" "1640 224 -136"
+}
+{
+"classname" "light"
+"light" "60"
+"origin" "-1472 1904 -88"
+}
+{
+"classname" "target_help"
+"targetname" "t140"
+"spawnflags" "2049"
+"message" "Mission accomplished.\nReturn to Waterfront Storage"
+"origin" "-80 144 -400"
+}
+{
+"spawnflags" "2048"
+"classname" "target_help"
+"targetname" "t140"
+"message" "Use air vent to\n gain access to\n bridge controls."
+"origin" "80 144 -400"
+}
+{
+"classname" "key_commander_head"
+"origin" "0 144 -488"
+"targetname" "t99"
+"spawnflags" "2049"
+"target" "t140"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2049"
+"angle" "90"
+"targetname" "t139"
+"origin" "0 32 -496"
+}
+{
+"model" "*5"
+"classname" "trigger_multiple"
+"wait" "4"
+"spawnflags" "2048"
+"message" "Security measures are offline."
+"targetname" "cehss"
+}
+{
+"model" "*6"
+"classname" "trigger_once"
+"target" "t138"
+"spawnflags" "2052"
+"targetname" "t35"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1728 1680 80"
+}
+{
+"origin" "-1152 768 -56"
+"spawnflags" "2049"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1200 768 -40"
+"spawnflags" "2049"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1096 768 -40"
+"spawnflags" "2049"
+"noise" "world/fan1.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-2376 1792 -184"
+"target" "t137"
+"delay" "1"
+"targetname" "t4"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1720 1792 -96"
+"angle" "0"
+"spawnflags" "3873"
+"classname" "monster_turret"
+}
+{
+"model" "*7"
+"classname" "func_explosive"
+"spawnflags" "2048"
+"targetname" "ex4"
+"health" "5"
+}
+{
+"model" "*8"
+"classname" "func_explosive"
+"spawnflags" "2048"
+"health" "5"
+"target" "t135"
+"targetname" "ex4"
+}
+{
+"origin" "520 576 -344"
+"classname" "monster_turret"
+"spawnflags" "6945"
+"angle" "0"
+}
+{
+"model" "*9"
+"target" "t39"
+"message" "Bridge enabled."
+"wait" "4"
+"angle" "0"
+"spawnflags" "5888"
+"classname" "func_button"
+"lip" "6"
+}
+{
+"origin" "1936 560 -296"
+"classname" "ammo_shells"
+}
+{
+"origin" "1368 544 -296"
+"classname" "ammo_slugs"
+}
+{
+"origin" "1296 536 -296"
+"classname" "item_health"
+}
+{
+"origin" "1512 536 -296"
+"classname" "item_health"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "1152 608 -192"
+}
+{
+"light" "50"
+"classname" "light"
+"origin" "1632 608 -160"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "1664 608 -192"
+}
+{
+"origin" "1408 128 -424"
+"classname" "monster_turret"
+"angle" "270"
+"spawnflags" "7177"
+}
+{
+"origin" "1408 128 -424"
+"spawnflags" "3873"
+"angle" "270"
+"classname" "monster_turret"
+}
+{
+"origin" "-776 512 -176"
+"target" "t136"
+"targetname" "t97"
+"delay" "1"
+"classname" "trigger_relay"
+}
+{
+"origin" "-856 512 -96"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "-992 552 -96"
+"message" "Dentention block located."
+"targetname" "t132"
+"spawnflags" "2049"
+"classname" "target_help"
+}
+{
+"model" "*10"
+"spawnflags" "2048"
+"targetname" "ex4"
+"classname" "func_explosive"
+"health" "5"
+}
+{
+"origin" "24 1792 -56"
+"classname" "item_health_large"
+}
+{
+"origin" "888 1264 -24"
+"classname" "item_health"
+}
+{
+"model" "*11"
+"targetname" "t57"
+"target" "t54"
+"spawnflags" "2048"
+"speed" "650"
+"classname" "func_train"
+}
+{
+"classname" "target_crosslevel_trigger"
+"targetname" "t110"
+"spawnflags" "2176"
+"origin" "-1424 1376 88"
+}
+{
+"targetname" "rb1b"
+"origin" "-2168 2440 -224"
+"classname" "info_player_coop"
+"angle" "270"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1b"
+"origin" "-2120 2488 -224"
+"classname" "info_player_coop"
+"angle" "270"
+"spawnflags" "3072"
+}
+{
+"targetname" "rb1b"
+"origin" "-2168 2504 -224"
+"classname" "info_player_coop"
+"angle" "270"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1b"
+"origin" "-2120 2408 -224"
+"angle" "270"
+"classname" "info_player_coop"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2144 2368 -192"
+}
+{
+"targetname" "rb1a"
+"origin" "2696 160 -288"
+"classname" "info_player_coop"
+"angle" "180"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1a"
+"origin" "2680 96 -288"
+"classname" "info_player_coop"
+"angle" "180"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1a"
+"origin" "2632 160 -288"
+"angle" "180"
+"classname" "info_player_coop"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1a"
+"origin" "2608 96 -288"
+"angle" "180"
+"classname" "info_player_coop"
+"spawnflags" "2048"
+}
+{
+"origin" "2560 128 -256"
+"light" "125"
+"classname" "light"
+}
+{
+"targetname" "rb1"
+"angle" "180"
+"classname" "info_player_coop"
+"origin" "1992 1760 32"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1"
+"angle" "180"
+"classname" "info_player_coop"
+"origin" "2048 1728 32"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1"
+"angle" "180"
+"classname" "info_player_coop"
+"origin" "2048 1856 32"
+"spawnflags" "2048"
+}
+{
+"targetname" "rb1"
+"classname" "info_player_coop"
+"angle" "180"
+"origin" "1992 1824 32"
+"spawnflags" "2048"
+}
+{
+"origin" "-2112 2568 -136"
+"map" "rbase2$rb2a"
+"targetname" "t134"
+"classname" "target_changelevel"
+"spawnflags" "2048"
+}
+{
+"model" "*12"
+"angle" "90"
+"target" "t134"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"origin" "-1408 1448 72"
+"delay" "2.3"
+"spawnflags" "2048"
+"target" "t133"
+"targetname" "t110"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1408 1488 72"
+"spawnflags" "2048"
+"target" "t133"
+"targetname" "t110"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1200 1688 72"
+"targetname" "t133"
+"noise" "world/dataspin.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "315"
+"spawnflags" "2049"
+"origin" "-552 288 -480"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "270"
+"spawnflags" "7169"
+"item" "ammo_bullets"
+"origin" "-936 616 -224"
+}
+{
+"classname" "monster_gunner"
+"spawnflags" "3841"
+"angle" "270"
+"origin" "-936 616 -224"
+}
+{
+"classname" "item_health_large"
+"origin" "2408 16 -296"
+}
+{
+"classname" "item_health_large"
+"origin" "2408 240 -296"
+}
+{
+"origin" "1640 168 -216"
+"message" "New orders will\n be forthcoming."
+"spawnflags" "2048"
+"classname" "target_help"
+"targetname" "t39"
+}
+{
+"classname" "target_help"
+"targetname" "t132"
+"spawnflags" "2048"
+"message" "Eliminate Tank Commander\n and retrieve its head."
+"origin" "-992 472 -96"
+}
+{
+"model" "*13"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"target" "t132"
+}
+{
+"targetname" "t135"
+"message" "Incoming marine D.O.A.\n Carry out his orders."
+"classname" "target_help"
+"spawnflags" "2049"
+"origin" "-792 1184 -224"
+}
+{
+"targetname" "t135"
+"classname" "target_help"
+"spawnflags" "2048"
+"origin" "-800 1328 -224"
+"message" "Access Logistics complex.\nLocate Dentention Block."
+}
+{
+"light" "50"
+"classname" "light"
+"origin" "1896 -128 -704"
+}
+{
+"light" "50"
+"classname" "light"
+"origin" "2048 -128 -704"
+}
+{
+"classname" "light"
+"light" "50"
+"origin" "1736 -128 -704"
+}
+{
+"model" "*14"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "1240 -168 -280"
+"light" "70"
+"classname" "light"
+}
+{
+"model" "*15"
+"targetname" "t90"
+"target" "t89"
+"spawnflags" "2052"
+"classname" "trigger_multiple"
+}
+{
+"origin" "-984 1896 120"
+"classname" "ammo_prox"
+}
+{
+"origin" "-984 1576 24"
+"classname" "item_health"
+}
+{
+"origin" "-984 1408 24"
+"classname" "item_health"
+}
+{
+"origin" "-1376 1632 24"
+"item" "ammo_bullets"
+"spawnflags" "2049"
+"angle" "0"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1488 1872 224"
+"targetname" "t131"
+"spawnflags" "2049"
+"angle" "315"
+"classname" "monster_gladiator"
+"item" "ammo_slugs"
+}
+{
+"origin" "-1016 1208 24"
+"classname" "monster_soldier"
+"spawnflags" "3585"
+"angle" "90"
+}
+{
+"origin" "-1056 1224 24"
+"spawnflags" "2305"
+"angle" "90"
+"classname" "monster_gunner"
+}
+{
+"origin" "-1280 1180 32"
+"targetname" "t130"
+"spawnflags" "2048"
+"classname" "target_explosion"
+}
+{
+"model" "*16"
+"targetname" "t13"
+"target" "t130"
+"spawnflags" "2048"
+"classname" "func_explosive"
+}
+{
+"origin" "-1432 1664 280"
+"angle" "0"
+"spawnflags" "7425"
+"classname" "monster_hover"
+}
+{
+"target" "t131"
+"origin" "-1440 1472 280"
+"classname" "monster_daedalus"
+"angle" "0"
+"spawnflags" "2049"
+}
+{
+"origin" "-1440 1664 280"
+"spawnflags" "6913"
+"angle" "0"
+"classname" "monster_daedalus"
+}
+{
+"angle" "270"
+"origin" "-1472 1336 352"
+"spawnflags" "2057"
+"classname" "monster_turret"
+}
+{
+"origin" "-1512 1120 216"
+"classname" "ammo_tesla"
+}
+{
+"origin" "-1432 1112 216"
+"classname" "item_health_large"
+}
+{
+"origin" "-1056 1216 224"
+"spawnflags" "2049"
+"angle" "180"
+"classname" "monster_medic_commander"
+"item" "ammo_cells"
+}
+{
+"origin" "-1624 1248 -240"
+"classname" "ammo_slugs"
+}
+{
+"origin" "-1632 1512 -240"
+"classname" "ammo_flechettes" // b#2: nails -> flechettes
+}
+{
+"origin" "-1376 1512 -232"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-1696 1528 -192"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-1568 1528 -192"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1440 1528 -192"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1472 1296 -192"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum2.wav"
+}
+{
+"origin" "-1664 1296 -192"
+"noise" "world/comp_hum2.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1432 1248 -232"
+"classname" "item_health_large"
+}
+{
+"origin" "-1512 1248 -232"
+"classname" "item_health_large"
+}
+{
+"origin" "-1696 1280 -224"
+"item" "ammo_cells"
+"spawnflags" "2049"
+"angle" "45"
+"classname" "monster_medic_commander"
+}
+{
+"origin" "-1600 1648 16"
+"targetname" "t128"
+"angle" "180"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "-1688 1896 32"
+"item" "ammo_grenades"
+"targetname" "t124"
+"target" "t128"
+"spawnflags" "2049"
+"angle" "270"
+"classname" "monster_gunner"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1824 1888 24"
+}
+{
+"origin" "-1624 1176 -40"
+"classname" "item_health_large"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-1664 1440 96"
+}
+{
+"origin" "-1760 1440 32"
+"item" "ammo_bullets"
+"spawnflags" "2049"
+"angle" "0"
+"classname" "monster_soldier_ss"
+}
+{
+"origin" "-1760 1504 32"
+"item" "ammo_shells"
+"angle" "0"
+"spawnflags" "2049"
+"classname" "monster_soldier"
+}
+{
+"model" "*17"
+"spawnflags" "5888"
+"classname" "func_wall"
+}
+{
+"model" "*18"
+"spawnflags" "2048"
+"targetname" "t126"
+"target" "t127"
+"classname" "func_explosive"
+}
+{
+"origin" "-1624 1176 132"
+"targetname" "t127"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"origin" "-1624 1176 164"
+"targetname" "t126"
+"classname" "monster_turret"
+"spawnflags" "7305"
+"angle" "-2"
+}
+{
+"origin" "-1624 1176 164"
+"targetname" "t126"
+"spawnflags" "7073"
+"classname" "monster_turret"
+"angle" "-2"
+}
+{
+"origin" "-1968 1472 -40"
+"target" "t126"
+"angle" "180"
+"spawnflags" "7169"
+"classname" "monster_hover"
+"item" "ammo_cells"
+}
+{
+"origin" "-1968 1456 -40"
+"target" "t126"
+"angle" "180"
+"spawnflags" "3841"
+"classname" "monster_daedalus"
+"item" "ammo_cells"
+}
+{
+"origin" "-1768 1320 32"
+"target" "t126"
+"angle" "315"
+"spawnflags" "2049"
+"item" "ammo_shells"
+"classname" "monster_soldier"
+}
+{
+"origin" "-1896 1800 8"
+"targetname" "t125"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "-1888 1696 32"
+"item" "ammo_bullets"
+"targetname" "t124"
+"spawnflags" "2049"
+"target" "t125"
+"classname" "monster_gunner"
+}
+{
+"origin" "-1568 1760 24"
+"classname" "ammo_prox"
+}
+{
+"origin" "-1632 1888 24"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-1888 1888 24"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-1568 1824 24"
+"classname" "item_armor_shard"
+}
+{
+"model" "*19"
+//"targetname" "t124" // b#1: self-target
+"target" "t124"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"origin" "-2008 1688 16"
+"classname" "item_health_large"
+}
+{
+"model" "*20"
+"target" "t122"
+"spawnflags" "2048"
+"classname" "trigger_once"
+}
+{
+"origin" "-616 2064 16"
+"targetname" "t121"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "-576 1936 32"
+"angle" "90"
+"targetname" "t122"
+"target" "t121"
+"spawnflags" "7681"
+"classname" "monster_gunner"
+}
+{
+"origin" "-576 1936 32"
+"targetname" "t122"
+"target" "t121"
+"spawnflags" "2305"
+"angle" "90"
+"classname" "monster_gladiator"
+}
+{
+"item" "ammo_grenades"
+"origin" "-1304 2144 -224"
+"spawnflags" "3841"
+"angle" "180"
+"classname" "monster_gunner"
+}
+{
+"item" "ammo_bullets"
+"origin" "-1304 2144 -224"
+"angle" "180"
+"spawnflags" "7169"
+"classname" "monster_soldier_ss"
+}
+{
+"item" "ammo_shells"
+"origin" "-1184 2040 -32"
+"angle" "135"
+"spawnflags" "2049"
+"classname" "monster_soldier"
+}
+{
+"origin" "-1008 2176 16"
+"targetname" "t120"
+"classname" "point_combat"
+"spawnflags" "2048"
+}
+{
+"origin" "-960 2048 32"
+"target" "t120"
+"spawnflags" "2049"
+"angle" "90"
+"targetname" "t118"
+"classname" "monster_gunner"
+}
+{
+"origin" "-1568 2080 68"
+"spawnflags" "2048"
+"targetname" "t119"
+"classname" "target_explosion"
+}
+{
+"model" "*21"
+"target" "t119"
+"targetname" "t118"
+"spawnflags" "2048"
+"classname" "func_explosive"
+}
+{
+"model" "*22"
+"targetname" "t118"
+"spawnflags" "5888"
+"classname" "func_wall"
+}
+{
+"targetname" "t118"
+"classname" "monster_turret"
+"angle" "-2"
+"spawnflags" "7305"
+"origin" "-1568 2080 100"
+}
+{
+"targetname" "t118"
+"origin" "-1568 2080 100"
+"spawnflags" "4001"
+"angle" "-2"
+"classname" "monster_turret"
+}
+{
+"target" "t118"
+"origin" "-1128 2176 24"
+"spawnflags" "2049"
+"angle" "180"
+"classname" "monster_daedalus"
+}
+{
+"origin" "-1304 2088 -168"
+"classname" "item_health"
+}
+{
+"origin" "-1640 2008 -240"
+"classname" "ammo_slugs"
+}
+{
+"origin" "-1624 2208 -240"
+"classname" "item_health_small"
+}
+{
+"origin" "-1616 2104 -240"
+"classname" "item_health_small"
+}
+{
+"origin" "-1640 2160 -240"
+"classname" "item_health_small"
+}
+{
+"origin" "-1120 1864 -240"
+"classname" "ammo_tesla"
+}
+{
+"targetname" "t116"
+"spawnflags" "2049"
+"origin" "-1264 1736 -240"
+"classname" "point_combat"
+}
+{
+"targetname" "t117"
+"target" "t116"
+"origin" "-1184 1888 -224"
+"spawnflags" "2049"
+"angle" "270"
+"classname" "monster_gunner"
+}
+{
+"origin" "-1056 1704 -240"
+"classname" "ammo_rockets"
+}
+{
+"origin" "-1584 1704 -168"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-1608 1896 -168"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-1464 1696 -168"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-1384 1704 -168"
+"classname" "item_armor_jacket"
+}
+{
+"origin" "-1816 1728 -232"
+"classname" "item_health_large"
+}
+{
+"origin" "-1368 1888 -232"
+"classname" "item_health_large"
+}
+{
+"origin" "-1952 1832 -224"
+"angle" "180"
+"spawnflags" "7425"
+"targetname" "t113"
+"target" "t115"
+"classname" "monster_soldier_ss"
+}
+{
+"target" "t117"
+"classname" "monster_soldier"
+"item" "ammo_shells"
+"spawnflags" "2049"
+"origin" "-1704 1688 -232"
+"angle" "90"
+}
+{
+"angle" "270"
+"origin" "-1896 1896 -232"
+"spawnflags" "2049"
+"item" "ammo_shells"
+"classname" "monster_soldier"
+}
+{
+"classname" "monster_soldier"
+"spawnflags" "3585"
+"angle" "90"
+"origin" "1888 -144 -288"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "0"
+"spawnflags" "2049"
+"targetname" "t4"
+"origin" "-2456 1792 32"
+}
+{
+"classname" "monster_daedalus"
+"angle" "90"
+"spawnflags" "6913"
+"origin" "-2048 1760 -80"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2048"
+"targetname" "t115"
+"origin" "-2056 1824 -240"
+}
+{
+"classname" "monster_gunner"
+"angle" "180"
+"spawnflags" "6913"
+"targetname" "t113"
+"target" "t115"
+"origin" "-1944 1832 -224"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2048"
+"targetname" "t112"
+"origin" "-2240 1840 16"
+}
+{
+"classname" "monster_medic_commander"
+"spawnflags" "2049"
+"angle" "0"
+"target" "t112"
+"targetname" "t113"
+"item" "ammo_cells"
+"origin" "-2336 1824 32"
+}
+{
+"model" "*23"
+"classname" "trigger_once"
+"target" "t113"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t12"
+"target" "t111"
+"delay" "10"
+"origin" "-616 1712 32"
+"spawnflags" "2048"
+}
+{
+"classname" "target_speaker"
+"targetname" "t111"
+"spawnflags" "2048"
+"noise" "world/uplink.wav"
+"origin" "-600 1680 32"
+}
+{
+"origin" "-1472 1376 264"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1024 1856 176"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t110"
+"target" "t14"
+"spawnflags" "2048"
+"origin" "-1448 1448 96"
+}
+{
+"classname" "trigger_relay"
+"targetname" "t110"
+"target" "t106"
+"spawnflags" "2048"
+"origin" "-1480 1448 8"
+}
+{
+"targetname" "t133"
+"classname" "target_speaker"
+"noise" "world/dataspin.wav"
+"spawnflags" "2050"
+"origin" "-1296 1688 72"
+}
+{
+"classname" "target_help"
+"targetname" "t110"
+"message" "Collect disk and\nreturn to\nTactical Command."
+"spawnflags" "2048"
+"origin" "-1496 1552 64"
+}
+{
+"model" "*24"
+"classname" "trigger_once"
+"spawnflags" "2052"
+"targetname" "t12"
+"target" "t110"
+}
+{
+"classname" "target_speaker"
+"noise" "world/dish1.wav"
+"spawnflags" "2048"
+"targetname" "t12"
+"origin" "-656 1688 72"
+}
+{
+"classname" "target_speaker"
+"noise" "world/dish1.wav"
+"spawnflags" "2048"
+"targetname" "t12"
+"origin" "-544 1688 72"
+}
+{
+"classname" "target_speaker"
+"targetname" "t12"
+"noise" "world/dish1.wav"
+"spawnflags" "2050"
+"origin" "-800 912 24"
+}
+{
+"classname" "target_speaker"
+"targetname" "t12"
+"noise" "world/dish1.wav"
+"spawnflags" "2050"
+"origin" "-552 912 24"
+}
+{
+"model" "*25"
+"spawnflags" "0"
+"classname" "func_wall"
+}
+{
+"model" "*26"
+"targetname" "t98"
+"target" "t107"
+"classname" "trigger_multiple"
+"spawnflags" "2052"
+}
+{
+"origin" "-1288 1632 48"
+"target" "t106"
+"targetname" "t104"
+"classname" "trigger_relay"
+"spawnflags" "2048"
+}
+{
+"origin" "-1120 1120 288"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+}
+{
+"origin" "-1312 1112 288"
+"classname" "target_speaker"
+"spawnflags" "1"
+"noise" "world/comp_hum3.wav"
+}
+{
+"origin" "-1216 1096 256"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "1"
+"classname" "target_speaker"
+}
+{
+"origin" "-1296 1712 96"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"origin" "-1200 1712 96"
+"noise" "world/comp_hum3.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"origin" "-1248 1688 96"
+"noise" "world/comp_hum1.wav"
+"spawnflags" "2049"
+"classname" "target_speaker"
+}
+{
+"origin" "-1184 1736 256"
+"targetname" "t101"
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1184 1736 176"
+"targetname" "t101"
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1312 1736 256"
+"targetname" "t101"
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "-1312 1736 176"
+"targetname" "t101"
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"targetname" "t105"
+"origin" "-1048 1184 312"
+"message" "Realign satillite array to\n interface with capital ship."
+"classname" "target_help"
+"spawnflags" "2048"
+}
+{
+"model" "*27"
+"message" "Data disk accepted"
+"targetname" "t104"
+"classname" "trigger_once"
+}
+{
+"message" "Bring uplink online using\n communications terminal."
+"origin" "-1232 1536 24"
+"targetname" "t104"
+"classname" "target_help"
+"spawnflags" "2048"
+}
+{
+"model" "*28"
+"targetname" "carosel"
+"message" "Terminal locked, data disk required."
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"model" "*29"
+"killtarget" "lesorac"
+"targetname" "t104"
+"spawnflags" "2052"
+"target" "t105"
+"classname" "trigger_once"
+}
+{
+"killtarget" "carosel"
+"origin" "-1288 1592 48"
+"target" "t104"
+"item" "key_data_cd"
+"targetname" "t103"
+"classname" "trigger_key"
+"spawnflags" "2048"
+}
+{
+"model" "*30"
+"target" "t103"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"targetname" "t104"
+"spawnflags" "2049"
+"origin" "-1248 1728 44"
+"classname" "key_data_cd"
+"target" "t142"
+}
+{
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"origin" "-1272 1696 24"
+"targetname" "t102"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"origin" "-1224 1696 24"
+"targetname" "t102"
+"classname" "target_speaker"
+}
+{
+"targetname" "t101"
+"origin" "-1312 1770 256"
+"spawnflags" "2120"
+"angle" "-2"
+"classname" "target_laser"
+}
+{
+"origin" "-1200 1624 256"
+"target" "t101"
+"spawnflags" "2048"
+"delay" ".5"
+"targetname" "t14"
+"classname" "trigger_relay"
+}
+{
+"origin" "-1232 1624 256"
+"target" "t102"
+"spawnflags" "2048"
+"delay" "1"
+"targetname" "t14"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t101"
+"origin" "-1184 1770 256"
+"spawnflags" "2120"
+"angle" "-2"
+"classname" "target_laser"
+}
+{
+"targetname" "t14"
+"origin" "-1056 1048 264"
+"spawnflags" "72"
+"angle" "-1"
+"classname" "target_laser"
+}
+{
+"model" "*31"
+"targetname" "t106"
+"spawnflags" "2050"
+"classname" "func_wall"
+}
+{
+"model" "*32"
+"targetname" "t105"
+"spawnflags" "2052"
+"target" "t100"
+"classname" "trigger_once"
+}
+{
+"model" "*33"
+"targetname" "lesorac"
+"message" "Array controls locked."
+"wait" "5"
+"classname" "trigger_multiple"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1696 1504 -192"
+}
+{
+"origin" "-1568 1504 -192"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1792 1472 -184"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1712 1344 -192"
+"light" "60"
+"classname" "light"
+}
+{
+"origin" "-1664 1312 -120"
+"light" "100"
+"classname" "light"
+}
+{
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"targetname" "t14"
+"origin" "-1056 1072 308"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"targetname" "t14"
+"origin" "-1056 1072 232"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2050"
+"noise" "world/l_hum2.wav"
+"targetname" "t14"
+"origin" "-1056 1072 384"
+"classname" "target_speaker"
+}
+{
+"origin" "-1312 1136 280"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-1472 1280 328"
+"light" "125"
+"classname" "light"
+}
+{
+"light" "130"
+"classname" "light"
+"origin" "-1664 1568 96"
+}
+{
+"origin" "-1856 1216 16"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-704 1280 -248"
+"target" "ex4"
+"targetname" "ex3"
+"classname" "trigger_relay"
+"delay" "2"
+"spawnflags" "2048"
+}
+{
+"classname" "info_player_start"
+"angle" "180"
+"targetname" "rb1"
+"origin" "2048 1792 32"
+}
+{
+"targetname" "rb1b"
+"classname" "info_player_start"
+"angle" "270"
+"origin" "-2144 2544 -224"
+}
+{
+"classname" "info_player_start"
+"angle" "180"
+"targetname" "rb1a"
+"origin" "2744 128 -288"
+}
+{
+"classname" "target_crosslevel_trigger"
+"targetname" "t99"
+"origin" "176 96 -280"
+"spawnflags" "2052"
+}
+{
+"classname" "monster_tank_commander"
+"angle" "270"
+"spawnflags" "2049"
+"targetname" "t35"
+"origin" "-8 88 -488"
+"deathtarget" "t99"
+"target" "t139"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-1696 1216 64"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-1472 1152 328"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-1280 1152 384"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-1088 1152 384"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1472 1216 232"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "-1056 1080 376"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1056 1080 224"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1504 1440 -120"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1504 1312 -120"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1664 1440 -120"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1440 1504 -192"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1376 1312 -120"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1376 1440 -120"
+}
+{
+"origin" "-2176 2568 -208"
+"message" "Uplink to capitol ship\n to reprogram data disk."
+"targetname" "t98"
+"spawnflags" "2049"
+"classname" "target_help"
+}
+{
+"message" "Locate and enable satellite\n uplink to capitol ship."
+"origin" "-2104 2568 -208"
+"targetname" "t98"
+"classname" "target_help"
+"spawnflags" "2048"
+}
+{
+"model" "*34"
+"target" "t98"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"message" "Disable laser grid and\n obtain commander's head."
+"origin" "-224 480 -224"
+"targetname" "t35"
+"spawnflags" "2048"
+"classname" "target_help"
+}
+{
+"targetname" "t96"
+"origin" "-112 560 -448"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"origin" "-424 512 -448"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"origin" "-480 224 -448"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"origin" "-480 -32 -448"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"origin" "-128 -32 -344"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+"origin" "160 560 -448"
+}
+{
+"targetname" "t96"
+"origin" "128 -32 -344"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+"origin" "-128 192 -344"
+}
+{
+"targetname" "t96"
+"origin" "128 192 -344"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"origin" "0 416 -272"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"targetname" "t96"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+"origin" "328 200 -272"
+}
+{
+"targetname" "t96"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+"origin" "328 416 -272"
+}
+{
+"targetname" "t96"
+"classname" "target_speaker"
+"spawnflags" "2050"
+"noise" "world/klaxon1.wav"
+"origin" "-208 416 -272"
+}
+{
+"origin" "-1352 1680 8"
+"targetname" "t13"
+"classname" "target_secret"
+"message" "You found a secret." // b#3: moved here
+"spawnflags" "2048"
+}
+{
+"origin" "-1280 1152 24"
+"light" "60"
+"classname" "light"
+}
+{
+"origin" "-800 552 -216"
+"light" "60"
+"classname" "light"
+}
+{
+"origin" "-552 416 -472"
+"light" "60"
+"classname" "light"
+}
+{
+"model" "*35"
+"target" "t97"
+"wait" "2"
+"_minlight" ".3"
+"angle" "90"
+"classname" "func_button"
+}
+{
+"model" "*36"
+"wait" "2"
+"_minlight" ".3"
+"target" "t97"
+"angle" "180"
+"classname" "func_button"
+}
+{
+"origin" "800 376 -296"
+"classname" "item_health_large"
+}
+{
+"origin" "864 32 -232"
+"classname" "item_health_large"
+}
+{
+"origin" "-552 -32 -488"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-496 -96 -488"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-552 -88 -488"
+"classname" "item_armor_shard"
+}
+{
+"origin" "-352 -104 -488"
+"classname" "ammo_flechettes" // b#2: nails -> flechettes
+}
+{
+"origin" "-416 168 -488"
+"classname" "item_health_large"
+}
+{
+"origin" "-352 168 -488"
+"classname" "ammo_tesla"
+}
+{
+"origin" "-552 88 -488"
+"classname" "ammo_prox"
+}
+{
+"origin" "-216 384 -272"
+"targetname" "t78"
+"target" "t96"
+"spawnflags" "2048"
+"classname" "trigger_relay"
+}
+{
+"origin" "-224 448 -272"
+"target" "t96"
+"spawnflags" "2048"
+"targetname" "t35"
+"classname" "trigger_relay"
+}
+{
+"targetname" "t96"
+"origin" "328 -24 -272"
+"noise" "world/klaxon1.wav"
+"spawnflags" "2050"
+"classname" "target_speaker"
+}
+{
+"spawnflags" "2048"
+"origin" "-136 0 -480"
+"item" "ammo_bullets"
+"targetname" "t35"
+"target" "t93"
+"angle" "270"
+"classname" "monster_soldier"
+}
+{
+"origin" "176 -24 -496"
+"targetname" "t95"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "-248 -32 -496"
+"targetname" "t94"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "0 -112 -496"
+"targetname" "t93"
+"angle" "90"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "160 256 -496"
+"targetname" "t92"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "-144 248 -496"
+"targetname" "t91"
+"spawnflags" "2049"
+"classname" "point_combat"
+}
+{
+"origin" "-2464 2176 -240"
+"classname" "ammo_flechettes" // b#2: nails -> flechettes
+}
+{
+"origin" "-1944 2120 -240"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-2464 1976 -240"
+"classname" "ammo_grenades"
+}
+{
+"origin" "-1976 2040 -240"
+"classname" "weapon_grenadelauncher"
+}
+{
+"origin" "-1968 1968 -256"
+"spawnflags" "2050"
+"classname" "misc_deadsoldier"
+}
+{
+"origin" "1544 -32 -296"
+"classname" "ammo_cells"
+}
+{
+"origin" "1360 424 -296"
+"classname" "ammo_rockets"
+"spawnflags" "2048"
+}
+{
+"origin" "1328 360 -296"
+"classname" "weapon_rocketlauncher"
+"spawnflags" "2048"
+}
+{
+"origin" "1304 432 -320"
+"spawnflags" "2064"
+"classname" "misc_deadsoldier"
+"angle" "270"
+}
+{
+"origin" "1904 400 -24"
+"spawnflags" "2305"
+"angle" "315"
+"classname" "monster_daedalus"
+}
+{
+"origin" "1752 88 -288"
+"item" "ammo_shells"
+"angle" "45"
+"spawnflags" "3585"
+"classname" "monster_soldier"
+}
+{
+"angle" "90"
+"origin" "1824 -144 -288"
+"spawnflags" "2305"
+"classname" "monster_gunner"
+"item" "ammo_bullets"
+}
+{
+"angle" "-2"
+"origin" "1408 32 -136"
+"spawnflags" "3873"
+"classname" "monster_turret"
+}
+{
+"angle" "-2"
+"origin" "1632 608 -136"
+"spawnflags" "2849"
+"classname" "monster_turret"
+}
+{
+"item" "ammo_cells"
+"origin" "2368 128 -288"
+"spawnflags" "2049"
+"angle" "180"
+"classname" "monster_medic_commander"
+}
+{
+"origin" "1184 608 -160"
+"classname" "light"
+"light" "50"
+}
+{
+"origin" "1408 544 -192"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "func_group"
+}
+{
+"origin" "1472 192 -192"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "1344 192 -192"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "1344 384 -192"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "1472 384 -192"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "1600 224 -192"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "1816 -128 -728"
+"classname" "item_health_small"
+}
+{
+"origin" "1896 -128 -728"
+"classname" "item_health_small"
+}
+{
+"origin" "1968 -128 -728"
+"classname" "item_health_small"
+}
+{
+"origin" "1720 -128 -728"
+"classname" "item_health_small"
+}
+{
+"origin" "352 -224 -296"
+"spawnflags" "2048"
+"classname" "item_armor_combat"
+}
+{
+"origin" "2048 -128 -728"
+"classname" "item_armor_combat"
+}
+{
+"classname" "func_group"
+}
+{
+"model" "*37"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*38"
+"classname" "func_button"
+"angle" "180"
+"spawnflags" "2048"
+"wait" "-1"
+"target" "t90"
+"message" "Door unlocked."
+}
+{
+"angle" "-2"
+"spawnflags" "2849"
+"classname" "monster_turret"
+"origin" "1184 608 -136"
+}
+{
+"angle" "-2"
+"classname" "monster_turret"
+"spawnflags" "3081"
+"origin" "1184 608 -136"
+}
+{
+"angle" "-2"
+"spawnflags" "3081"
+"classname" "monster_turret"
+"origin" "1632 608 -136"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "7177"
+"origin" "1408 32 -136"
+"angle" "-2"
+}
+{
+"classname" "light"
+"light" "75"
+"angle" "-2"
+"origin" "1088 432 -496"
+}
+{
+"origin" "1088 480 -496"
+"angle" "-2"
+"light" "90"
+"classname" "light"
+}
+{
+"origin" "960 432 -496"
+"angle" "-2"
+"light" "75"
+"classname" "light"
+}
+{
+"classname" "ammo_shells"
+"origin" "1232 -208 -496"
+}
+{
+"classname" "item_health_small"
+"origin" "1376 -224 -488"
+}
+{
+"classname" "item_health_small"
+"origin" "1432 -224 -488"
+}
+{
+"classname" "item_health_small"
+"origin" "1320 -224 -488"
+}
+{
+"spawnflags" "3841"
+"classname" "monster_gunner"
+"angle" "45"
+"origin" "1216 -80 -480"
+"item" "ammo_grenades"
+}
+{
+"angle" "135"
+"classname" "monster_gunner"
+"spawnflags" "3841"
+"origin" "1592 -96 -480"
+"item" "ammo_bullets"
+}
+{
+"classname" "monster_gunner"
+"angle" "90"
+"spawnflags" "2049"
+"origin" "1536 -248 -480"
+"item" "ammo_bullets"
+}
+{
+"classname" "monster_hover"
+"angle" "0"
+"spawnflags" "2049"
+"target" "t88"
+"origin" "1304 -480 -232"
+}
+{
+"classname" "item_health"
+"origin" "1440 -232 -296"
+}
+{
+"classname" "monster_gunner"
+"angle" "135"
+"spawnflags" "2049"
+"origin" "1512 -232 -288"
+}
+{
+"classname" "monster_turret"
+"origin" "1408 -612 -256"
+"targetname" "t88"
+"angle" "90"
+"spawnflags" "2177"
+}
+{
+"classname" "target_explosion"
+"origin" "1408 -580 -256"
+"targetname" "t87"
+"spawnflags" "2048"
+}
+{
+"model" "*39"
+"classname" "func_wall"
+"spawnflags" "5888"
+}
+{
+"model" "*40"
+"classname" "func_explosive"
+"spawnflags" "2048"
+"target" "t87"
+"targetname" "t88"
+}
+{
+"light" "60"
+"classname" "light"
+"origin" "1552 -112 -160"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "1472 -64 -200"
+}
+{
+"classname" "item_health_large"
+"origin" "1248 32 -296"
+}
+{
+"classname" "target_help"
+"targetname" "t39"
+"spawnflags" "2049"
+"message" "Return to Waterfront\n Storage Facility."
+"origin" "1632 240 -216"
+}
+{
+"model" "*41"
+"lip" "6"
+"classname" "func_button"
+"spawnflags" "2048"
+"angle" "0"
+"wait" "-1"
+"message" "Bridge enabled."
+"target" "t39"
+}
+{
+"model" "*42"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-96 512 -280"
+}
+{
+"spawnflags" "5888"
+"classname" "item_armor_body"
+"origin" "352 -224 -296"
+}
+{
+"classname" "monster_soldier"
+"spawnflags" "7169"
+"origin" "472 352 -288"
+"item" "ammo_shells"
+"angle" "180"
+}
+{
+"classname" "monster_gunner"
+"angle" "180"
+"spawnflags" "3841"
+"origin" "472 360 -288"
+"item" "ammo_grenades"
+}
+{
+"classname" "monster_medic"
+"angle" "90"
+"spawnflags" "2049"
+"targetname" "t86"
+"origin" "352 -176 -288"
+}
+{
+"classname" "item_armor_shard"
+"origin" "352 544 -304"
+}
+{
+"classname" "item_armor_shard"
+"origin" "288 544 -304"
+}
+{
+"classname" "item_armor_shard"
+"origin" "416 544 -304"
+}
+{
+"classname" "monster_gladiator"
+"angle" "0"
+"spawnflags" "2049"
+"origin" "-192 424 -288"
+"target" "t86"
+"item" "ammo_slugs"
+}
+{
+"classname" "item_health_small"
+"origin" "1056 200 -296"
+}
+{
+"classname" "item_health_small"
+"origin" "1056 248 -296"
+}
+{
+"classname" "item_health_small"
+"origin" "1056 296 -296"
+}
+{
+"classname" "item_health_small"
+"origin" "1056 152 -296"
+}
+{
+"model" "*43"
+"classname" "func_wall"
+"spawnflags" "0"
+}
+{
+"classname" "light"
+"light" "90"
+"origin" "352 -192 -280"
+}
+{
+"item" "ammo_bullets"
+"target" "t95"
+"targetname" "t35"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"origin" "32 0 -480"
+"spawnflags" "2049"
+}
+{
+"item" "ammo_bullets"
+"target" "t94"
+"targetname" "t35"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"origin" "-136 104 -480"
+"spawnflags" "2049"
+}
+{
+"target" "t91"
+"targetname" "t35"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"origin" "-8 184 -480"
+"spawnflags" "2049"
+}
+{
+"target" "t92"
+"targetname" "t35"
+"classname" "monster_soldier_ss"
+"angle" "270"
+"origin" "112 152 -480"
+"spawnflags" "2049"
+}
+{
+"spawnflags" "2048"
+"classname" "info_notnull"
+"team" "rightlaser"
+"targetname" "t84"
+"origin" "176 -192 -448"
+}
+{
+"spawnflags" "2048"
+"classname" "info_notnull"
+"team" "rightlaser"
+"targetname" "t85"
+"origin" "176 -192 -480"
+}
+{
+"spawnflags" "2048"
+"classname" "info_notnull"
+"team" "rightlaser"
+"targetname" "t83"
+"origin" "176 -192 -416"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048"
+"targetname" "t79"
+"target" "t80"
+"origin" "176 312 -536"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"targetname" "t81"
+"target" "t82"
+"origin" "176 312 -536"
+}
+{
+"spawnflags" "2048"
+"classname" "path_corner"
+"target" "t79"
+"targetname" "t82"
+"origin" "176 -192 -536"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048"
+"targetname" "t80"
+"target" "t81"
+"origin" "-200 312 -536"
+}
+{
+"model" "*44"
+"classname" "func_train"
+"spawnflags" "2050"
+"target" "t82"
+"team" "rightlaser"
+"targetname" "t74"
+}
+{
+"classname" "trigger_relay"
+"origin" "-64 8 -376"
+"target" "t74"
+"targetname" "t78"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"target" "t73"
+"delay" "5"
+"origin" "56 8 -376"
+"targetname" "t78"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"origin" "-176 -192 -448"
+"classname" "info_notnull"
+"team" "leftlaser"
+"targetname" "t76"
+}
+{
+"spawnflags" "2048"
+"origin" "-176 -192 -416"
+"classname" "info_notnull"
+"team" "leftlaser"
+"targetname" "t77"
+}
+{
+"spawnflags" "2048"
+"classname" "info_notnull"
+"origin" "-176 -192 -480"
+"team" "leftlaser"
+"targetname" "t75"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048"
+"targetname" "t69"
+"target" "t70"
+"origin" "-192 312 -536"
+}
+{
+"model" "*45"
+"spawnflags" "2050"
+"classname" "func_train"
+"target" "t72"
+"targetname" "t74"
+"team" "leftlaser"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048"
+"targetname" "t71"
+"target" "t72"
+"origin" "-192 312 -536"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048"
+"target" "t69"
+"targetname" "t72"
+"origin" "-192 -192 -536"
+}
+{
+"classname" "path_corner"
+"spawnflags" "2048"
+"targetname" "t70"
+"target" "t71"
+"origin" "184 312 -536"
+}
+{
+"classname" "trigger_relay"
+"origin" "-64 32 -344"
+"targetname" "t35"
+"delay" "5"
+"target" "t74"
+"spawnflags" "2048"
+}
+{
+"classname" "trigger_relay"
+"origin" "56 32 -344"
+"targetname" "t35"
+"target" "t73"
+"spawnflags" "2048"
+}
+{
+"model" "*46"
+"classname" "func_button"
+"angle" "90"
+"lip" "4"
+"_minlight" ".3"
+"wait" "-1"
+"spawnflags" "2048"
+"target" "t15"
+"message" "Containment fields deactivated."
+}
+{
+"origin" "-896 1280 -248"
+"delay" ".6"
+"spawnflags" "2048"
+"targetname" "ex5"
+"classname" "target_explosion"
+"dmg" "150"
+}
+{
+"target" "ex4"
+"dmg" "150"
+"origin" "-880 1248 -240"
+"spawnflags" "2048"
+"targetname" "ex5"
+"classname" "target_explosion"
+}
+{
+"origin" "-920 1208 -256"
+"delay" ".2"
+"spawnflags" "2048"
+"targetname" "ex5"
+"classname" "target_explosion"
+}
+{
+"origin" "-896 1216 -248"
+"delay" ".6"
+"spawnflags" "2048"
+"targetname" "ex5"
+"classname" "target_explosion"
+"dmg" "150"
+}
+{
+"origin" "-24 440 -480"
+"spawnflags" "2049"
+"angle" "90"
+"classname" "monster_soldier"
+"targetname" "t67"
+}
+{
+"origin" "392 8 -464"
+"classname" "item_health_large"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2056"
+"item" "ammo_rockets"
+"origin" "384 168 -488"
+"angle" "270"
+}
+{
+"origin" "384 216 -464"
+"spawnflags" "5888"
+"classname" "ammo_rockets"
+}
+{
+"model" "*47"
+"spawnflags" "2048"
+"angle" "-1"
+"classname" "func_door"
+"targetname" "t86"
+"wait" "-1"
+}
+{
+"origin" "336 -112 -512"
+"item" "ammo_cells"
+"spawnflags" "2064"
+"classname" "misc_deadsoldier"
+"angle" "90"
+}
+{
+"origin" "992 608 -576"
+"angle" "-2"
+"light" "125"
+"classname" "light"
+}
+{
+"classname" "ammo_rockets"
+"origin" "424 464 -488"
+}
+{
+"model" "*48"
+"classname" "func_wall"
+"spawnflags" "2054"
+"targetname" "t15"
+}
+{
+"spawnflags" "2049"
+"classname" "point_combat"
+"targetname" "t68"
+"origin" "232 560 -504"
+}
+{
+"classname" "monster_gunner"
+"angle" "135"
+"spawnflags" "2049"
+"origin" "280 472 -488"
+"item" "ammo_grenades"
+"target" "t68"
+"targetname" "t67"
+}
+{
+"model" "*49"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"target" "t67"
+}
+{
+"model" "*50"
+"classname" "func_wall"
+"spawnflags" "5888"
+}
+{
+"model" "*51"
+"classname" "func_explosive"
+"target" "t66"
+"spawnflags" "2048"
+"targetname" "t67"
+}
+{
+"classname" "target_explosion"
+"targetname" "t66"
+"spawnflags" "2048"
+"origin" "-544 512 -316"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "2185"
+"angle" "-2"
+"targetname" "t67"
+"origin" "-544 512 -284"
+}
+{
+"item" "ammo_shells"
+"spawnflags" "2049"
+"angle" "315"
+"classname" "monster_soldier"
+"origin" "-552 616 -480"
+}
+{
+"classname" "monster_soldier"
+"angle" "45"
+"spawnflags" "3841"
+"item" "ammo_shells"
+"origin" "-552 416 -480"
+}
+{
+"classname" "item_armor_jacket"
+"origin" "-1056 696 -168"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-344 616 -496"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-296 616 -496"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-392 616 -496"
+}
+{
+"classname" "item_health_large"
+"origin" "-296 424 -488"
+}
+{
+"classname" "monster_medic_commander"
+"spawnflags" "2049"
+"angle" "135"
+"targetname" "t65"
+"origin" "920 -88 -288"
+}
+{
+"classname" "monster_gunner"
+"spawnflags" "7169"
+"angle" "90"
+"target" "t65"
+"origin" "664 -136 -288"
+}
+{
+"classname" "monster_gladiator"
+"angle" "90"
+"spawnflags" "6913"
+"target" "t65"
+"origin" "656 -136 -288"
+}
+{
+"classname" "item_health_large"
+"origin" "-1048 1576 -240"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1240 1168 -232"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1240 1112 -232"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1240 1056 -232"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1240 1000 -232"
+}
+{
+"classname" "item_armor_shard"
+"origin" "-1248 1224 -232"
+}
+{
+"model" "*52"
+"classname" "func_wall"
+"spawnflags" "4096"
+}
+{
+"model" "*53"
+"classname" "func_explosive"
+"spawnflags" "3840"
+"targetname" "t60"
+"target" "t64"
+}
+{
+"classname" "target_explosion"
+"spawnflags" "3840"
+"targetname" "t64"
+"origin" "-1056 1504 -60"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "4001"
+"angle" "-2"
+"targetname" "t60"
+"origin" "-1056 1504 -28"
+}
+{
+"classname" "target_explosion"
+"targetname" "t63"
+"spawnflags" "2304"
+"origin" "-1056 1056 -60"
+}
+{
+"model" "*54"
+"classname" "func_explosive"
+"spawnflags" "2816"
+"target" "t63"
+"targetname" "t60"
+}
+{
+"model" "*55"
+"classname" "func_wall"
+"spawnflags" "5120"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "7049"
+"angle" "-2"
+"targetname" "t60"
+"origin" "-1056 1056 -28"
+}
+{
+"classname" "item_health_large"
+"origin" "-856 616 -232"
+}
+{
+"spawnflags" "2048"
+"classname" "point_combat"
+"targetname" "t62"
+"origin" "-936 432 -240"
+}
+{
+"spawnflags" "2049"
+"angle" "180"
+"classname" "monster_soldier_ss"
+"origin" "-1048 568 -224"
+}
+{
+"classname" "monster_soldier_ss"
+"angle" "180"
+"spawnflags" "2049"
+"target" "t62"
+"item" "ammo_bullets"
+"origin" "-880 432 -224"
+}
+{
+"_color" "0.000000 0.501961 1.000000"
+"light" "125"
+"classname" "light"
+"origin" "-1216 432 -160"
+}
+{
+"model" "*56"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"target" "t61"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2049"
+"targetname" "t59"
+"origin" "-1184 800 -248"
+}
+{
+"classname" "monster_gunner"
+"angle" "45"
+"spawnflags" "2049"
+"target" "t59"
+"targetname" "t60"
+"origin" "-1248 680 -224"
+"item" "ammo_grenades"
+}
+{
+"model" "*57"
+"classname" "func_wall"
+"spawnflags" "5632"
+}
+{
+"model" "*58"
+"classname" "func_explosive"
+"spawnflags" "2304"
+"targetname" "t61"
+}
+{
+"classname" "target_explosion"
+"targetname" "t61" // b#4: added this
+"spawnflags" "2304"
+"origin" "-1152 608 -60"
+}
+{
+"classname" "monster_turret"
+"angle" "-2"
+"spawnflags" "6537"
+"origin" "-1152 608 -28"
+"targetname" "t61"
+}
+{
+"classname" "monster_soldier"
+"angle" "90"
+"spawnflags" "2048"
+"origin" "-1056 1040 -224"
+"target" "t60"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_gunner"
+"angle" "315"
+"spawnflags" "2049"
+"origin" "-1232 1536 -224"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1256 1696 -208"
+}
+{
+"model" "*59"
+"targetname" "t107"
+"classname" "func_door"
+"angle" "-2"
+"_minlight" ".3"
+"sounds" "2"
+"message" "Access denied."
+"spawnflags" "2048"
+"wait" "-1"
+}
+{
+"targetname" "ex3"
+"origin" "-640 1216 -200"
+"delay" ".2"
+"spawnflags" "2048"
+"classname" "target_explosion"
+}
+{
+"targetname" "ex2"
+"origin" "-336 1224 -32"
+"spawnflags" "2048"
+"classname" "target_explosion"
+}
+{
+"targetname" "ex1"
+"origin" "-24 1240 144"
+"spawnflags" "2048"
+"classname" "target_explosion"
+}
+{
+"origin" "128 1216 208"
+"delay" ".2"
+"targetname" "t57"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"origin" "128 1144 208"
+"delay" ".2"
+"targetname" "t57"
+"classname" "target_explosion"
+"spawnflags" "2048"
+}
+{
+"model" "*60"
+"killtarget" "scardead"
+"health" "2"
+"target" "t57"
+"mass" "500"
+"spawnflags" "2048"
+"classname" "func_explosive"
+}
+{
+"origin" "188 1180 236"
+"spawnflags" "2048"
+"targetname" "scardead"
+"classname" "info_notnull"
+}
+{
+"origin" "-704 1480 8"
+"killtarget" "scardead"
+"target" "t56"
+"targetname" "t55"
+"classname" "target_anger"
+"spawnflags" "2048"
+}
+{
+"model" "*61"
+"target" "t55"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"pathtarget" "ex5"
+"speed" "850"
+"spawnflags" "2048"
+"targetname" "t53"
+"classname" "path_corner"
+"origin" "-970 1188 -320"
+}
+{
+"pathtarget" "ex3"
+"speed" "800"
+"spawnflags" "2048"
+"target" "t53"
+"targetname" "t52"
+"origin" "-642 1188 -200"
+"classname" "path_corner"
+}
+{
+"pathtarget" "ex2"
+"speed" "750"
+"spawnflags" "2048"
+"target" "t52"
+"targetname" "t51"
+"classname" "path_corner"
+"origin" "-330 1188 -32"
+}
+{
+"pathtarget" "ex1"
+"speed" "700"
+"spawnflags" "2048"
+"target" "t51"
+"targetname" "t50"
+"origin" "-18 1180 144"
+"classname" "path_corner"
+}
+{
+"spawnflags" "2048"
+"targetname" "t54"
+"target" "t50"
+"origin" "270 1172 240"
+"classname" "path_corner"
+}
+{
+"classname" "point_combat"
+"wait" "10"
+"targetname" "t49"
+"origin" "-800 1576 112"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "3585"
+"angle" "135"
+"classname" "monster_hover"
+"origin" "32 1336 168"
+"target" "t49"
+"item" "ammo_cells"
+}
+{
+"classname" "monster_hover"
+"angle" "135"
+"spawnflags" "2817"
+"origin" "128 960 -240"
+}
+{
+"classname" "monster_daedalus"
+"angle" "135"
+"spawnflags" "2305"
+"origin" "32 1344 168"
+"target" "t49"
+"item" "ammo_cells"
+}
+{
+"classname" "item_health_large"
+"origin" "-216 1472 -184"
+}
+{
+"classname" "ammo_slugs"
+"spawnflags" "0"
+"origin" "112 1304 -56"
+}
+{
+"classname" "weapon_railgun"
+"spawnflags" "5888"
+"origin" "56 1344 -56"
+}
+{
+"classname" "item_health_small"
+"origin" "296 1928 -56"
+}
+{
+"classname" "item_health_small"
+"origin" "368 1952 -56"
+}
+{
+"classname" "item_health_small"
+"origin" "224 1912 -56"
+}
+{
+"classname" "monster_medic_commander"
+"angle" "315"
+"spawnflags" "2049"
+"origin" "-848 1696 -224"
+"targetname" "t58"
+}
+{
+"model" "*62"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"target" "t47"
+}
+{
+"model" "*63"
+"classname" "func_wall"
+"spawnflags" "5888"
+}
+{
+"classname" "target_explosion"
+"spawnflags" "2048"
+"targetname" "t48"
+"origin" "1666 1980 240"
+}
+{
+"model" "*64"
+"classname" "func_explosive"
+"spawnflags" "2048"
+"targetname" "t47"
+"target" "t48"
+}
+{
+"classname" "monster_turret"
+"spawnflags" "2185"
+"angle" "180"
+"origin" "1700 1984 240"
+"targetname" "t47"
+}
+{
+"origin" "800 1312 0"
+"item" "ammo_bullets"
+"spawnflags" "2049"
+"angle" "0"
+"classname" "monster_gunner"
+}
+{
+"origin" "1280 2208 16"
+"classname" "weapon_proxlauncher"
+}
+{
+"message" "Rendevous at entrance \n with incoming marine."
+"origin" "2096 1832 104"
+"targetname" "t46"
+"classname" "target_help"
+"spawnflags" "2048"
+}
+{
+"message" "Locate entrance to \n Logistics Complex."
+"origin" "2096 1752 104"
+"spawnflags" "2049"
+"targetname" "t46"
+"classname" "target_help"
+}
+{
+"model" "*65"
+"target" "t46"
+"classname" "trigger_once"
+"spawnflags" "2048"
+}
+{
+"model" "*66"
+"classname" "func_button"
+"angle" "270"
+"_minlight" ".3"
+"wait" "2"
+"message" "Lift activated."
+"target" "t4"
+}
+{
+"targetname" "t56"
+"spawnflags" "2049"
+"classname" "monster_gladiator"
+"angle" "0"
+"origin" "-584 1480 -240"
+"target" "t58"
+}
+{
+"item" "ammo_cells"
+"classname" "monster_daedalus"
+"angle" "135"
+"spawnflags" "3841"
+"origin" "1568 1704 408"
+}
+{
+"classname" "item_sphere_hunter"
+"spawnflags" "5888"
+"origin" "1640 2112 80"
+}
+{
+"classname" "item_health_large"
+"origin" "1576 2128 24"
+}
+{
+"classname" "item_health_large"
+"origin" "1416 2240 24"
+}
+{
+"item" "ammo_bullets"
+"classname" "monster_soldier_ss"
+"spawnflags" "2049"
+"target" "t43"
+"targetname" "t42"
+"origin" "1080 1496 8"
+}
+{
+"item" "ammo_shells"
+"classname" "monster_soldier"
+"spawnflags" "2305"
+"target" "t44"
+"targetname" "t42"
+"origin" "1024 1496 8"
+}
+{
+"classname" "point_combat"
+"origin" "1216 2080 -16"
+"spawnflags" "2048"
+"targetname" "t43"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2048"
+"origin" "1000 1736 -16"
+"targetname" "t44"
+}
+{
+"classname" "point_combat"
+"spawnflags" "2049"
+"targetname" "t41"
+"origin" "1616 1952 8"
+}
+{
+"classname" "monster_soldier"
+"angle" "45"
+"spawnflags" "2049"
+"target" "t41"
+"origin" "1512 1864 24"
+}
+{
+"model" "*67"
+"classname" "trigger_once"
+"spawnflags" "2048"
+"target" "t42"
+}
+{
+"item" "ammo_grenades"
+"classname" "monster_gunner"
+"angle" "225"
+"spawnflags" "2049"
+"origin" "1672 2272 32"
+}
+{
+"classname" "ammo_prox"
+"origin" "1224 2220 24"
+}
+{
+"classname" "misc_deadsoldier"
+"spawnflags" "2050"
+"angle" "135"
+"origin" "1248 2160 0"
+}
+{
+"classname" "item_armor_shard"
+"origin" "1184 2184 24"
+}
+{
+"classname" "item_armor_shard"
+"origin" "1168 2136 24"
+}
+{
+"classname" "target_changelevel"
+"targetname" "t40"
+"map" "rware2$rw2b"
+"origin" "2776 96 -208"
+"spawnflags" "2048"
+}
+{
+"model" "*68"
+"angle" "0"
+"classname" "trigger_multiple"
+"target" "t40"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "2720 128 -256"
+}
+{
+"origin" "2016 568 -256"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "2016 672 -512"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "1904 672 -512"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "2016 568 -448"
+"light" "120"
+"classname" "light"
+}
+{
+"model" "*69"
+"targetname" "t219"
+"message" "Access denied."
+"spawnflags" "2048"
+"classname" "func_door"
+"angle" "-2"
+"_minlight" ".3"
+}
+{
+"model" "*70"
+"origin" "1916 254 -328"
+"targetname" "t39"
+"_minlight" ".3"
+"speed" "35"
+"spawnflags" "161"
+"classname" "func_door_rotating"
+"distance" "90"
+}
+{
+"model" "*71"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*72"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"model" "*73"
+"_minlight" ".3"
+"angle" "-1"
+"classname" "func_door"
+"spawnflags" "2048"
+}
+{
+"model" "*74"
+"message" "Access denied."
+"_minlight" ".3"
+"angle" "-1"
+"classname" "func_door"
+"targetname" "t89"
+"spawnflags" "2048"
+}
+{
+"origin" "1280 -224 -200"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "1472 -224 -200"
+"light" "120"
+"classname" "light"
+}
+{
+"origin" "1552 -16 -160"
+"classname" "light"
+"light" "60"
+}
+{
+"origin" "1344 -64 -200"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "272 288 -256"
+"classname" "light"
+"light" "80"
+}
+{
+"light" "80"
+"classname" "light"
+"origin" "272 96 -256"
+}
+{
+"origin" "224 496 -256"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "224 336 -256"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "432 288 -256"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-32 496 -256"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "448 0 -240"
+}
+{
+"origin" "448 192 -240"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "288 480 -456"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "192 560 -456"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "416 480 -456"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "0 560 -456"
+}
+{
+"origin" "-1216 1360 264"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1088 1360 264"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-192 416 -240"
+}
+{
+"origin" "96 512 -240"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "352 512 -240"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "448 416 -240"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "304 192 -240"
+}
+{
+"origin" "304 0 -240"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "352 -64 -240"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"_color" "1.000000 0.000000 0.000000"
+"origin" "544 128 -432"
+}
+{
+"model" "*75"
+"classname" "func_wall"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2180"
+"origin" "-154 -90 -480"
+"targetname" "t74"
+"dmg" "1000"
+"angle" "90"
+"classname" "target_laser"
+"target" "t85"
+}
+{
+"spawnflags" "2180"
+"origin" "-154 -90 -448"
+"targetname" "t74"
+"dmg" "1000"
+"angle" "90"
+"classname" "target_laser"
+"target" "t84"
+}
+{
+"spawnflags" "2180"
+"origin" "-154 -90 -416"
+"targetname" "t74"
+"classname" "target_laser"
+"angle" "90"
+"dmg" "1000"
+"target" "t83"
+}
+{
+"spawnflags" "2180"
+"origin" "154 -90 -448"
+"targetname" "t74"
+"classname" "target_laser"
+"angle" "90"
+"dmg" "1000"
+"target" "t76"
+}
+{
+"spawnflags" "2180"
+"origin" "154 -90 -480"
+"targetname" "t74"
+"classname" "target_laser"
+"angle" "90"
+"dmg" "1000"
+"target" "t75"
+}
+{
+"spawnflags" "2180"
+"origin" "154 -90 -416"
+"dmg" "1000"
+"targetname" "t74"
+"angle" "90"
+"classname" "target_laser"
+"target" "t77"
+}
+{
+"model" "*76"
+"lip" "-4"
+"wait" "-1"
+"speed" "30"
+"_minlight" ".3"
+"spawnflags" "2081"
+"angle" "-1"
+"classname" "func_door"
+"targetname" "t73"
+}
+{
+"model" "*77"
+"target" "t35"
+"_minlight" ".3"
+"lip" "4"
+"wait" "-1"
+"angle" "180"
+"classname" "func_button"
+"spawnflags" "2048"
+"message" "Security counter measures activated."
+"killtarget" "cehss"
+}
+{
+"origin" "-520 96 -448"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 0.501961"
+}
+{
+"origin" "-544 -32 -448"
+"classname" "light"
+"light" "100"
+"_color" "1.000000 1.000000 0.501961"
+}
+{
+"origin" "-896 448 -128"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-896 576 -128"
+"light" "100"
+"classname" "light"
+}
+{
+"spawnflags" "2048"
+"origin" "432 -32 -432"
+"targetname" "t34"
+"classname" "target_explosion"
+}
+{
+"origin" "0 424 -456"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-160 560 -456"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-264 -32 -448"
+"light" "60"
+"classname" "light"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-352 512 -280"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-480 512 -280"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-480 512 -400"
+}
+{
+"classname" "light"
+"light" "150"
+"origin" "-352 512 -400"
+}
+{
+"model" "*78"
+"spawnflags" "2048"
+"target" "t34"
+"classname" "func_explosive"
+"mass" "100"
+"_minlight" ".3"
+"health" "5"
+}
+{
+"model" "*79"
+"_minlight" ".3"
+"angle" "-2"
+"classname" "func_door"
+"spawnflags" "2048"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-360 -32 -440"
+}
+{
+"model" "*80"
+"classname" "func_wall"
+"spawnflags" "2054"
+"_minlight" ".3"
+"targetname" "t15"
+}
+{
+"model" "*81"
+"classname" "func_wall"
+"spawnflags" "2054"
+"_minlight" ".3"
+"targetname" "t15"
+}
+{
+"origin" "-224 32 -456"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-224 -96 -456"
+}
+{
+"model" "*82"
+"classname" "func_button"
+"angle" "0"
+"_minlight" ".3"
+"wait" "-1"
+"spawnflags" "2048"
+"target" "t78"
+"message" "Security counter measures deactvated."
+"targetname" "t138"
+}
+{
+"origin" "-1024 512 -136"
+"classname" "light"
+"light" "100"
+}
+{
+"_color" "0.000000 0.501961 1.000000"
+"light" "125"
+"classname" "light"
+"origin" "-1056 432 -160"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1216 512 -136"
+}
+{
+"model" "*83"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"model" "*84"
+"targetname" "t136"
+"_minlight" ".3"
+"angle" "-1"
+"lip" "144"
+"classname" "func_plat2"
+"spawnflags" "36"
+}
+{
+"origin" "-688 512 -416"
+"light" "150"
+"classname" "light"
+}
+{
+"origin" "-688 512 -88"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-688 512 -160"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "64 304 -240"
+}
+{
+"origin" "-64 304 -240"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-1216 1352 264"
+"light" "80"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "80"
+"origin" "-1088 1352 264"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-1856 1792 56"
+}
+{
+"classname" "func_group"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-704 2064 56"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-576 1808 56"
+}
+{
+"light" "75"
+"classname" "light"
+"origin" "1728 1728 96"
+}
+{
+"model" "*85"
+"team" "camrod"
+"_minlight" ".3"
+"angle" "90"
+"classname" "func_door"
+}
+{
+"model" "*86"
+"team" "camrod"
+"_minlight" ".3"
+"angle" "270"
+"classname" "func_door"
+}
+{
+"origin" "2016 1680 96"
+"light" "180"
+"classname" "light"
+}
+{
+"origin" "1952 1712 96"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "1952 1872 96"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "2080 1872 96"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "2016 1904 96"
+"classname" "light"
+"light" "180"
+}
+{
+"origin" "2080 1712 96"
+"light" "100"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"origin" "1936 1792 160"
+"light" "50"
+"classname" "light"
+}
+{
+"origin" "1792 1792 96"
+"classname" "light"
+"light" "75"
+}
+{
+"origin" "1728 1856 96"
+"light" "75"
+"classname" "light"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-512 1728 56"
+}
+{
+"classname" "target_changelevel"
+"targetname" "t9"
+"origin" "2072 1768 120"
+"map" "rware2$rw2a"
+"spawnflags" "2048"
+}
+{
+"model" "*87"
+"targetname" "4idiots"
+"classname" "trigger_multiple"
+"target" "t9"
+"angle" "0"
+"spawnflags" "2048"
+}
+{
+"spawnflags" "2048"
+"targetname" "t12"
+"classname" "misc_satellite_dish"
+"angle" "0"
+"origin" "-544 800 64"
+}
+{
+"origin" "-2144 2528 -192"
+"light" "100"
+"classname" "light"
+}
+{
+"light" "140"
+"origin" "640 1504 48"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "896 1296 48"
+"light" "140"
+}
+{
+"classname" "light"
+"origin" "672 1312 48"
+"light" "140"
+}
+{
+"classname" "light"
+"origin" "664 1728 32"
+"light" "140"
+}
+{
+"classname" "light"
+"origin" "1032 1432 48"
+"light" "140"
+}
+{
+"classname" "light"
+"light" "100"
+"_color" "0.000000 0.501961 1.000000"
+"origin" "-2432 2144 -192"
+}
+{
+"origin" "-2240 2192 -72"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "-2048 2192 -72"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-704 1728 56"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*88"
+"targetname" "t100"
+"target" "t12"
+"classname" "func_button"
+"angle" "270"
+"wait" "-1"
+"spawnflags" "2048"
+}
+{
+"model" "*89"
+"classname" "func_door"
+"angle" "-2"
+"_minlight" ".3"
+"sounds" "2"
+"spawnflags" "2048"
+}
+{
+"model" "*90"
+"spawnflags" "2048"
+"classname" "func_wall"
+}
+{
+"origin" "-576 1920 56"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-584 2056 56"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-832 2064 56"
+"classname" "light"
+"light" "100"
+}
+{
+"origin" "-2448 1792 -152"
+"light" "150"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2240 2048 32"
+}
+{
+"light" "125"
+"classname" "light"
+"origin" "-2304 2048 -72"
+}
+{
+"spawnflags" "2048"
+"targetname" "t12"
+"origin" "-800 800 64"
+"angle" "0"
+"classname" "misc_satellite_dish"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-2048 2048 32"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-1984 2048 -72"
+}
+{
+"origin" "-2448 1792 152"
+"light" "80"
+"classname" "light"
+}
+{
+"origin" "-2144 2048 -72"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "-2432 2016 -192"
+"classname" "light"
+"light" "100"
+"_color" "0.000000 0.501961 1.000000"
+}
+{
+"origin" "-2520 2112 -240"
+"_color" "0.000000 0.501961 1.000000"
+"light" "75"
+"classname" "light"
+}
+{
+"light" "150"
+"classname" "light"
+"origin" "-2448 1792 104"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-2448 1792 -16"
+}
+{
+"origin" "-1152 1632 -192"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "115"
+"origin" "-1152 1472 -136"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1472 1952 -192"
+}
+{
+"origin" "-1152 1792 -136"
+"light" "125"
+"classname" "light"
+}
+{
+"model" "*91"
+"targetname" "t98"
+"target" "t10"
+"spawnflags" "2052"
+"classname" "trigger_multiple"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-992 1696 312"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-992 1440 312"
+}
+{
+"light" "120"
+"classname" "light"
+"origin" "-1056 1568 312"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1152 1568 312"
+}
+{
+"origin" "-1184 1856 176"
+"light" "100"
+"classname" "light"
+}
+{
+"origin" "-1408 1856 312"
+"classname" "light"
+"light" "130"
+}
+{
+"origin" "-1216 1856 312"
+"classname" "light"
+"light" "130"
+}
+{
+"classname" "light"
+"light" "130"
+"origin" "-1024 1856 312"
+}
+{
+"classname" "light"
+"light" "115"
+"origin" "-1152 1216 -136"
+}
+{
+"classname" "light"
+"light" "115"
+"origin" "-1152 1344 -136"
+}
+{
+"origin" "-1152 1088 -136"
+"light" "115"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-1152 768 -120"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1080 696 -72"
+}
+{
+"origin" "-1080 840 -72"
+"light" "100"
+"classname" "light"
+}
+{
+"model" "*92"
+"origin" "-1152 768 32"
+"classname" "func_rotating"
+"_minlight" ".3"
+"spawnflags" "2051"
+"speed" "600"
+}
+{
+"origin" "-1152 928 -192"
+"classname" "light"
+"light" "100"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1024 1248 56"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1152 1312 56"
+}
+{
+"origin" "-1088 1280 256"
+"light" "120"
+"classname" "light"
+}
+{
+"targetname" "t102"
+"classname" "target_laser"
+"angle" "-2"
+"spawnflags" "2120"
+"origin" "-1248 1730 76"
+}
+{
+"model" "*93"
+"spawnflags" "2048"
+"targetname" "t105"
+"classname" "func_button"
+"angle" "270"
+"wait" "-1"
+"lip" "8"
+"target" "t14"
+"_minlight" ".3"
+}
+{
+"origin" "-1744 1632 96"
+"classname" "light"
+"light" "80"
+}
+{
+"origin" "-1472 1536 312"
+"classname" "light"
+"light" "130"
+}
+{
+"model" "*94"
+"target" "t13"
+"_minlight" ".3"
+"health" "1"
+"lip" "4"
+"wait" "-1"
+"angle" "0"
+"classname" "func_button"
+"spawnflags" "2048"
+}
+{
+"model" "*95"
+"targetname" "t137"
+"classname" "func_plat2"
+"lip" "144"
+"_minlight" ".2"
+"angle" "-2"
+"spawnflags" "32"
+}
+{
+"classname" "light"
+"light" "125"
+"origin" "-1472 1792 -136"
+}
+{
+"origin" "-2048 1728 -192"
+"classname" "light"
+"light" "125"
+"_color" "0.000000 0.501961 1.000000"
+}
+{
+"_color" "0.000000 0.501961 1.000000"
+"light" "125"
+"classname" "light"
+"origin" "-1856 1728 -192"
+}
+{
+"model" "*96"
+"targetname" "t10"
+"message" "Access denied."
+"sounds" "2"
+"_minlight" ".3"
+"angle" "-2"
+"classname" "func_door"
+"spawnflags" "2048"
+"wait" "-1"
+}
+{
+"model" "*97"
+"target" "t4"
+"angle" "270"
+"classname" "func_button"
+"message" "Lift activated."
+"wait" "2"
+"_minlight" ".3"
+}
+{
+"origin" "-2048 1792 56"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "-2240 1792 56"
+"classname" "light"
+"light" "125"
+}
+{
+"origin" "-1664 1792 56"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-2240 1728 -192"
+"_color" "0.000000 0.501961 1.000000"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-2208 1792 -192"
+"classname" "light"
+"light" "115"
+}
+{
+"origin" "-1984 1792 -192"
+"_color" "0.000000 0.501961 1.000000"
+"light" "125"
+"classname" "light"
+}
+{
+"origin" "-2048 1792 -136"
+"light" "125"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1312 1696 312"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1312 1440 312"
+}
+{
+"classname" "light"
+"light" "120"
+"origin" "-1248 1568 312"
+}
+{
+"origin" "-1472 1408 64"
+"classname" "light"
+"light" "110"
+}
+{
+"origin" "-1472 1728 312"
+"classname" "light"
+"light" "130"
+}
+{
+"light" "110"
+"classname" "light"
+"origin" "-1472 1536 64"
+}
+{
+"origin" "-1224 696 -72"
+"light" "100"
+"classname" "light"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1224 840 -72"
+}
+{
+"classname" "light"
+"light" "100"
+"origin" "-1280 1248 56"
+}
+{
+"light" "100"
+"classname" "light"
+"origin" "-1120 1136 280"
+}
+{
+"origin" "-1280 1280 256"
+"classname" "light"
+"light" "120"
+}
+{
+"origin" "544 0 -432"
+"_color" "1.000000 0.000000 0.000000"
+"light" "80"
+"classname" "light"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "704 72 -432"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "864 64 -432"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "1024 64 -504"
+}
+{
+"_color" "1.000000 0.000000 0.000000"
+"light" "80"
+"classname" "light"
+"origin" "1024 256 -504"
+}
+{
+"angle" "-2"
+"light" "125"
+"classname" "light"
+"origin" "1056 608 -576"
+}
+{
+"classname" "light"
+"light" "90"
+"angle" "-2"
+"origin" "960 496 -496"
+}
+{
+"angle" "-2"
+"light" "150"
+"classname" "light"
+"origin" "992 608 -448"
+}
+{
+"classname" "light"
+"light" "150"
+"angle" "-2"
+"origin" "1056 608 -448"
+}
+{
+"classname" "light"
+"light" "125"
+"angle" "-2"
+"origin" "1408 256 -584"
+}
+{
+"angle" "-2"
+"light" "150"
+"classname" "light"
+"origin" "1408 256 -456"
+}
+{
+"angle" "-2"
+"light" "80"
+"classname" "light"
+"origin" "1504 64 -584"
+}
+{
+"classname" "light"
+"light" "150"
+"angle" "-2"
+"origin" "1504 160 -456"
+}
+{
+"origin" "1312 160 -456"
+"classname" "light"
+"light" "150"
+"angle" "-2"
+}
+{
+"origin" "1408 64 -584"
+"angle" "-2"
+"light" "80"
+"classname" "light"
+}
+{
+"targetname" "t32"
+"origin" "1060 256 -496"
+"spawnflags" "2053"
+"angle" "180"
+"classname" "target_laser"
+"dmg" "1000"
+}
+{
+"origin" "1080 184 -504"
+"spawnflags" "2049"
+"wait" "2.5"
+"random" "2"
+"target" "t32"
+"classname" "func_timer"
+}
+{
+"origin" "1032 256 -496"
+"targetname" "t32"
+"spawnflags" "1"
+"noise" "world/l_hum2.wav"
+"classname" "target_speaker"
+}
+{
+"origin" "1008 256 -496"
+"targetname" "t32"
+"classname" "target_speaker"
+"noise" "world/l_hum2.wav"
+"spawnflags" "1"
+}
+{
+"model" "*98"
+"origin" "1088 468 -496"
+"speed" "400"
+"_minlight" ".3"
+"spawnflags" "9"
+"classname" "func_rotating"
+}
+{
+"light" "80"
+"origin" "1304 40 -536"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "1280 -32 -640"
+"light" "100"
+}
+{
+"light" "100"
+"origin" "1280 -32 -440"
+"classname" "light"
+}
+{
+"classname" "light"
+"origin" "1536 -32 -440"
+"light" "100"
+}
+{
+"classname" "light"
+"origin" "1536 -32 -640"
+"light" "100"
+}
+{
+"classname" "light"
+"origin" "1408 -32 -640"
+"light" "100"
+}
+{
+"classname" "light"
+"origin" "1304 40 -640"
+"light" "80"
+}
+{
+"classname" "light"
+"light" "125"
+"angle" "-2"
+"origin" "1312 160 -584"
+}
+{
+"origin" "1504 160 -584"
+"classname" "light"
+"light" "125"
+"angle" "-2"
+}
+{
+"classname" "light"
+"light" "80"
+"angle" "-2"
+"origin" "1312 64 -584"
+}


### PR DESCRIPTION
This PR addresses the issues in https://github.com/yquake2/rogue/issues/119.

The following changes were made:
* Commented out the "targetname" field from the offending trigger_once. Saw no reason for it to be there, as this trigger is intended to alert monsters.
* Added the missing t61 targetname to the target_explosion.

There were also some other minor things, like fixing secret sound effects (the message was printed by the trigger rather than the target_secret, causing 2 sound effects to play in overlap).

All my changes are fully traceable through the comments in the .ent file.