### PR TITLE
Added missing include, fixing compilation in Linux and MacOS

### DIFF
--- a/src/player/weapon.c
+++ b/src/player/weapon.c
@@ -7,6 +7,7 @@
 
 #include "../header/local.h"
 #include "../monster/misc/player.h"
+#include <limits.h>
 
 #define PLAYER_NOISE_SELF 0
 #define PLAYER_NOISE_IMPACT 1


### PR DESCRIPTION
Rogue version of https://github.com/yquake2/yquake2/pull/1059
`limits.h` has to be manually included in Linux and MacOS.