### PR TITLE
Workarounds for naggy help icons

### DIFF
--- a/src/g_target.c
+++ b/src/g_target.c
@@ -7,6 +7,9 @@
 
 #include "header/local.h"
 
+#define TARGET_HELP_PRIMARY 1
+#define TARGET_HELP_THINK_DELAY 0.3f
+
 #define LASER_ON 0x0001
 #define LASER_RED 0x0002
 #define LASER_GREEN 0x0004
@@ -153,6 +156,50 @@ SP_target_speaker(edict_t *ent)
 
 /* ========================================================== */
 
+static void
+Target_Help_Apply(const char *msg, int is_primary)
+{
+	char *curr;
+	size_t sz;
+
+	if (!msg)
+	{
+		return;
+	}
+
+	if (is_primary)
+	{
+		curr = game.helpmessage1;
+		sz = sizeof(game.helpmessage1);
+	}
+	else
+	{
+		curr = game.helpmessage2;
+		sz = sizeof(game.helpmessage2);
+	}
+
+	if (strcmp(curr, msg) == 0)
+	{
+		return;
+	}
+
+	Q_strlcpy(curr, msg, sz - 1);
+
+	game.helpchanged++;
+}
+
+void
+Target_Help_Think(edict_t *ent)
+{
+	if (!ent)
+	{
+		return;
+	}
+
+	Target_Help_Apply(ent->message, ent->spawnflags & TARGET_HELP_PRIMARY);
+	ent->think = NULL;
+}
+
 void
 Use_Target_Help(edict_t *ent, edict_t *other /* unused */, edict_t *activator /* unused */)
 {
@@ -161,16 +208,18 @@ Use_Target_Help(edict_t *ent, edict_t *other /* unused */, edict_t *activator /*
 		return;
 	}
 
-	if (ent->spawnflags & 1)
+	if (level.time > TARGET_HELP_THINK_DELAY)
 	{
-		strncpy(game.helpmessage1, ent->message, sizeof(game.helpmessage2) - 1);
+		Target_Help_Apply(ent->message, ent->spawnflags & TARGET_HELP_PRIMARY);
 	}
 	else
 	{
-		strncpy(game.helpmessage2, ent->message, sizeof(game.helpmessage1) - 1);
+		/* The game is still pre-loading so delay the help message a bit,
+		   otherwise its changes to game structure will leak past save loads
+		*/
+		ent->think = Target_Help_Think;
+		ent->nextthink = TARGET_HELP_THINK_DELAY;
 	}
-
-	game.helpchanged++;
 }
 
 /*

--- a/src/savegame/tables/gamefunc_decs.h
+++ b/src/savegame/tables/gamefunc_decs.h
@@ -928,6 +928,7 @@ extern void SP_target_secret ( edict_t * ent ) ;
 extern void use_target_secret ( edict_t * ent , edict_t * other , edict_t * activator ) ;
 extern void SP_target_help ( edict_t * ent ) ;
 extern void Use_Target_Help ( edict_t * ent , edict_t * other , edict_t * activator ) ;
+extern void Target_Help_Think ( edict_t * ent );
 extern void SP_target_speaker ( edict_t * ent ) ;
 extern void Use_Target_Speaker ( edict_t * ent , edict_t * other , edict_t * activator ) ;
 extern void SP_target_temp_entity ( edict_t * ent ) ;

--- a/src/savegame/tables/gamefunc_list.h
+++ b/src/savegame/tables/gamefunc_list.h
@@ -928,6 +928,7 @@
 {"use_target_secret", (byte *)use_target_secret},
 {"SP_target_help", (byte *)SP_target_help},
 {"Use_Target_Help", (byte *)Use_Target_Help},
+{"Target_Help_Think", (byte *)Target_Help_Think},
 {"SP_target_speaker", (byte *)SP_target_speaker},
 {"Use_Target_Speaker", (byte *)Use_Target_Speaker},
 {"SP_target_temp_entity", (byte *)SP_target_temp_entity},

--- a/stuff/mapfixes/rhangar2.ent
+++ b/stuff/mapfixes/rhangar2.ent
@@ -64,7 +64,7 @@
 {
 "classname" "trigger_relay"
 "targetname" "t11"
-"delay" "5"
+"delay" "0.3" // b#2: added this
 "killtarget" "t399"
 "target" "t11help" // b#2: added this
 "origin" "96 -480 8"


### PR DESCRIPTION
A rogue version of PR https://github.com/yquake2/yquake2/pull/1123.

Additionally:
* Updated rhangar2.ent: Reduced delay of target_help activation at level start from 5 seconds to 0.3. Was greatly exaggerating the need for a delay.

* Replaced strncpy with Q_strlcpy.