### PR TITLE
Fixed machinegun guard AI freeze bug

### DIFF
--- a/src/monster/soldier/soldier.c
+++ b/src/monster/soldier/soldier.c
@@ -724,6 +724,11 @@ soldier_fire(edict_t *self, int in_flash_number)
 
 			if (angle < 0.9)  /* ~25 degree angle */
 			{
+				if (level.time >= self->wait)
+				{
+					self->monsterinfo.aiflags &= ~AI_HOLD_FRAME;
+				}
+
 				return;
 			}
 		}
@@ -756,6 +761,11 @@ soldier_fire(edict_t *self, int in_flash_number)
 
 		if ((tr.ent != self->enemy) && (tr.ent != world))
 		{
+			if (level.time >= self->wait)
+			{
+				self->monsterinfo.aiflags &= ~AI_HOLD_FRAME;
+			}
+
 			return;
 		}
 	}


### PR DESCRIPTION
This PR addresses https://github.com/yquake2/rogue/issues/130.

Rogue added new AI checks that make the guard not shoot in certain cases, like if the aim angle is too steep or if there is an obstacle in the way, like a barrel or another monster. Because the machinegun guards use `AI_HOLD_FRAME` during their shoot frames, if Rogue's checks fail and the function returns, the `self->wait` timer will not be checked and so they get stuck in `AI_HOLD_FRAME` until you make those checks pass again by making yourself visible and shootable.

Adding checks for `self->wait` to clear `AI_HOLD_FRAME` before those exrra return statements avoids this issue.