### PR TITLE
Fix: remove unused variables

### DIFF
--- a/src/g_newai.c
+++ b/src/g_newai.c
@@ -421,7 +421,7 @@ monsterlost_checkhint(edict_t *self)
 	edict_t *closest;
 	float closest_range = 1000000;
 	edict_t *start, *destination;
-	int count1 = 0, count2 = 0, count4 = 0, count5 = 0;
+	int count = 0;
 	float r;
 	int i;
 	qboolean hint_path_represented[MAX_HINT_CHAINS];
@@ -461,8 +461,6 @@ monsterlost_checkhint(edict_t *self)
 
 		while (e)
 		{
-			count1++;
-
 			if (e->monster_hint_chain)
 			{
 				e->monster_hint_chain = NULL;
@@ -493,8 +491,6 @@ monsterlost_checkhint(edict_t *self)
 
 		if (r > 512)
 		{
-			count2++;
-
 			if (checkpoint)
 			{
 				checkpoint->monster_hint_chain = e->monster_hint_chain;
@@ -522,8 +518,6 @@ monsterlost_checkhint(edict_t *self)
 
 		if (!visible(self, e))
 		{
-			count4++;
-
 			if (checkpoint)
 			{
 				checkpoint->monster_hint_chain = e->monster_hint_chain;
@@ -550,7 +544,7 @@ monsterlost_checkhint(edict_t *self)
 		}
 
 		/* if it passes all the tests, it's a keeper */
-		count5++;
+		count++;
 		checkpoint = e;
 		e = e->monster_hint_chain;
 	}
@@ -561,7 +555,7 @@ monsterlost_checkhint(edict_t *self)
 	   chains, seeing whether any can see the player. first,
 	   we figure out which hint chains we have represented
 	   in monster_pathchain */
-	if (count5 == 0)
+	if (count == 0)
 	{
 		return false;
 	}
@@ -585,9 +579,7 @@ monsterlost_checkhint(edict_t *self)
 		e = e->monster_hint_chain;
 	}
 
-	count2 = 0;
-	count4 = 0;
-	count5 = 0;
+	count = 0;
 
 	/* now, build the target_pathchain which contains all of
 	   the hint_path nodes we need to check for validity
@@ -633,8 +625,6 @@ monsterlost_checkhint(edict_t *self)
 
 		if (r > 512)
 		{
-			count2++;
-
 			if (checkpoint)
 			{
 				checkpoint->target_hint_chain = e->target_hint_chain;
@@ -658,8 +648,6 @@ monsterlost_checkhint(edict_t *self)
 
 		if (!visible(self->enemy, e))
 		{
-			count4++;
-
 			if (checkpoint)
 			{
 				checkpoint->target_hint_chain = e->target_hint_chain;
@@ -682,7 +670,7 @@ monsterlost_checkhint(edict_t *self)
 		}
 
 		/* if it passes all the tests, it's a keeper */
-		count5++;
+		count++;
 		checkpoint = e;
 		e = e->target_hint_chain;
 	}
@@ -701,7 +689,7 @@ monsterlost_checkhint(edict_t *self)
 	   "monster valid" nodes by which ones have "target valid" nodes on them. Once
 	   this filter is finished, we select the closest "monster valid" node, and go to it. */
 
-	if (count5 == 0)
+	if (count == 0)
 	{
 		return false;
 	}
@@ -915,7 +903,7 @@ void
 InitHintPaths(void)
 {
 	edict_t *e, *current;
-	int field, i, count2;
+	int field, i;
 
 	hint_paths_present = 0;
 
@@ -965,7 +953,6 @@ InitHintPaths(void)
 
 	for (i = 0; i < num_hint_paths; i++)
 	{
-		count2 = 1;
 		current = hint_path_start[i];
 		current->hint_chain_id = i;
 		e = G_Find(NULL, field, current->target);
@@ -988,7 +975,6 @@ InitHintPaths(void)
 				break;
 			}
 
-			count2++;
 			current->hint_chain = e;
 			current = e;
 			current->hint_chain_id = i;

--- a/src/g_spawn.c
+++ b/src/g_spawn.c
@@ -304,10 +304,7 @@ G_FixTeams(void)
 {
 	edict_t *e, *e2, *chain;
 	int i, j;
-	int c, c2;
-
-	c = 0;
-	c2 = 0;
+	int c = 0;
 
 	for (i = 1, e = g_edicts + i; i < globals.num_edicts; i++, e++)
 	{
@@ -330,7 +327,6 @@ G_FixTeams(void)
 				e->teamchain = NULL;
 				e->flags &= ~FL_TEAMSLAVE;
 				c++;
-				c2++;
 
 				for (j = 1, e2 = g_edicts + j;
 					 j < globals.num_edicts;
@@ -353,7 +349,6 @@ G_FixTeams(void)
 
 					if (!strcmp(e->team, e2->team))
 					{
-						c2++;
 						chain->teamchain = e2;
 						e2->teammaster = e;
 						e2->teamchain = NULL;


### PR DESCRIPTION
When `make` is processing, I've got a warnings such as:

```
src/g_newai.c:424:6: warning: variable 'count1' set but not used [-Wunused-but-set-variable]
  424 |         int count1 = 0, count2 = 0, count4 = 0, count5 = 0;
      |             ^
src/g_newai.c:424:18: warning: variable 'count2' set but not used [-Wunused-but-set-variable]
  424 |         int count1 = 0, count2 = 0, count4 = 0, count5 = 0;
      |                         ^
src/g_newai.c:424:30: warning: variable 'count4' set but not used [-Wunused-but-set-variable]
  424 |         int count1 = 0, count2 = 0, count4 = 0, count5 = 0;
      |                                     ^
src/g_newai.c:918:16: warning: variable 'count2' set but not used [-Wunused-but-set-variable]
  918 |         int field, i, count2;
      |                       ^
src/g_spawn.c:307:9: warning: variable 'c2' set but not used [-Wunused-but-set-variable]
  307 |         int c, c2;
      |                ^
```

I have removed these unused variables. Tested on macOS 15, it just works fine.